### PR TITLE
fix urutan siswa salah saat generate laporan

### DIFF
--- a/app/Models/SiswaModel.php
+++ b/app/Models/SiswaModel.php
@@ -74,7 +74,9 @@ class SiswaModel extends Model
          'LEFT'
       )
          ->join('tb_jurusan', 'tb_kelas.id_jurusan = tb_jurusan.id', 'left')
-         ->where(['tb_siswa.id_kelas' => $id_kelas])->findAll();
+         ->where(['tb_siswa.id_kelas' => $id_kelas])
+         ->orderBy('nama_siswa')
+         ->findAll();
    }
 
    public function createSiswa($nis, $nama, $idKelas, $jenisKelamin, $noHp)


### PR DESCRIPTION
# Fix fatal bug :pray:

Resolve #117, #78, #69

Lupa untuk memberikan `orderBy('nama_siswa')` saat mengambil data siswa menyebabkan data siswa dan absensi tidak sinkron di laporan


```php
# PresensiSiswaModel.php
public function getPresensiByKelasTanggal($idKelas, $tanggal)
 {
    return $this->setTable('tb_siswa')
       ->select('*')
       ->join(...)
       ->join(...)
       ->where(...)
       ->orderBy('nama_siswa') # << ORDER BY NAMA SAAT MENGAMBIL DATA ABSENSI
       ->findAll();
 }
```

```php
# SiswaModel.php
public function getSiswaByKelas($id_kelas)
 {
    return $this->join(...)
       ->join(...)
       ->where(...)
       ->orderBy('nama_siswa') # << SEBELUMNYA TIDAK ADA, DAN MENJADI `orderBy('id_siswa')` SECARA DEFAULT 
       ->findAll();
 }
```