### PR TITLE
feat: add QR code print feature with 4-column grid layout

### DIFF
--- a/app/Config/Routes.php
+++ b/app/Config/Routes.php
@@ -172,15 +172,20 @@ $routes->group('admin', function (RouteCollection $routes) {
       $routes->post('guru', 'Admin\QRGenerator::generateQrGuru');
    });
 
-   // ── QR Download (qr.generate) ──
-   $routes->group('qr', ['filter' => 'permission:qr.generate'], function ($routes) {
-      $routes->get('siswa/download', 'Admin\QRGenerator::downloadAllQrSiswa');
-      $routes->get('siswa/(:any)/download', 'Admin\QRGenerator::downloadQrSiswa/$1');
-      $routes->get('siswa/(:any)/view', 'Admin\QRGenerator::viewQrSiswa/$1');
-      $routes->get('guru/download', 'Admin\QRGenerator::downloadAllQrGuru');
-      $routes->get('guru/(:any)/download', 'Admin\QRGenerator::downloadQrGuru/$1');
-      $routes->get('guru/(:any)/view', 'Admin\QRGenerator::viewQrGuru/$1');
-   });
+    // ── QR Download & Print (qr.generate) ──
+    $routes->group('qr', ['filter' => 'permission:qr.generate'], function ($routes) {
+       $routes->get('siswa/download', 'Admin\QRGenerator::downloadAllQrSiswa');
+       $routes->get('siswa/(:any)/download', 'Admin\QRGenerator::downloadQrSiswa/$1');
+       $routes->get('siswa/(:any)/view', 'Admin\QRGenerator::viewQrSiswa/$1');
+       $routes->get('siswa/print', 'Admin\QRGenerator::printQrSiswa');
+       $routes->get('siswa/print/(:any)', 'Admin\QRGenerator::printQrSiswa/$1');
+       $routes->get('siswa/print-single/(:any)', 'Admin\QRGenerator::printQrSiswaSingle/$1');
+       $routes->get('guru/download', 'Admin\QRGenerator::downloadAllQrGuru');
+       $routes->get('guru/(:any)/download', 'Admin\QRGenerator::downloadQrGuru/$1');
+       $routes->get('guru/(:any)/view', 'Admin\QRGenerator::viewQrGuru/$1');
+       $routes->get('guru/print', 'Admin\QRGenerator::printQrGuru');
+       $routes->get('guru/print-single/(:any)', 'Admin\QRGenerator::printQrGuruSingle/$1');
+    });
 
    // ── Laporan (attendance.view) ──
    $routes->group('laporan', ['filter' => 'permission:attendance.view'], function ($routes) {
@@ -230,8 +235,9 @@ $routes->group('teacher', ['filter' => 'permission:teacher.access'], function (R
    $routes->get('dashboard/live-stats', 'Teacher\Dashboard::getLiveStats');
    $routes->get('laporan', 'Teacher\Reports::index');
    $routes->post('laporan/generate', 'Teacher\Reports::generate');
-   $routes->get('qr', 'Teacher\QRCode::index');
-   $routes->get('qr/download', 'Teacher\QRCode::download');
+    $routes->get('qr', 'Teacher\QRCode::index');
+    $routes->get('qr/download', 'Teacher\QRCode::download');
+    $routes->get('qr/print', 'Teacher\QRCode::print');
    $routes->get('attendance', 'Teacher\Dashboard::attendance');
    $routes->get('attendance/(:any)', 'Teacher\Dashboard::attendance/$1');
    $routes->post('attendance/get-list', 'Teacher\Dashboard::getAttendanceList');

--- a/app/Controllers/Admin/QRGenerator.php
+++ b/app/Controllers/Admin/QRGenerator.php
@@ -339,14 +339,195 @@ class QRGenerator extends BaseController
       return self::UPLOADS_PATH . DIRECTORY_SEPARATOR . "qr-siswa/{$unique_code}.png";
    }
 
-   protected function getKelasJurusanSlug(string $idKelas)
-   {
-      $kelas = (new KelasModel)->getKelas($idKelas);
-      ;
-      if ($kelas) {
-         return url_title($kelas->kelas, lowercase: true);
-      } else {
-         return false;
-      }
-   }
+    protected function getKelasJurusanSlug(string $idKelas)
+    {
+       $kelas = (new KelasModel)->getKelas($idKelas);
+       ;
+       if ($kelas) {
+          return url_title($kelas->kelas, lowercase: true);
+       } else {
+          return false;
+       }
+    }
+
+    public function printQrSiswa($idKelas = null)
+    {
+       $siswaModel = new SiswaModel();
+       $kelasModel = new KelasModel();
+       $slugCache = [];
+
+       if ($idKelas) {
+          $kelas = $kelasModel->getKelas($idKelas);
+          if (!$kelas) {
+             session()->setFlashdata(['msg' => 'Kelas tidak ditemukan', 'error' => true]);
+             return redirect()->back();
+           }
+          $siswaList = $siswaModel->getSiswaByKelas($idKelas);
+       } else {
+          $kelas = null;
+          $siswaList = $siswaModel->getAllSiswaWithKelas();
+       }
+
+       $items = [];
+       foreach ($siswaList as $siswa) {
+          $idKelasSiswa = $siswa['id_kelas'];
+          if (!isset($slugCache[$idKelasSiswa])) {
+             $slugCache[$idKelasSiswa] = $this->getKelasJurusanSlug($idKelasSiswa) ?? 'tmp';
+          }
+          $kelasSlug = $slugCache[$idKelasSiswa];
+          $this->qrCodeFilePath = self::UPLOADS_PATH . "qr-siswa/$kelasSlug/";
+          if (!file_exists($this->qrCodeFilePath)) {
+             mkdir($this->qrCodeFilePath, recursive: true);
+          }
+          $this->qrCode->setForegroundColor($this->foregroundColor);
+          $this->label->setTextColor($this->foregroundColor);
+          $filePath = $this->generate(
+             nama: $siswa['nama_siswa'],
+             nomor: $siswa['nis'],
+             unique_code: $siswa['unique_code'],
+          );
+
+          $filename = url_title($siswa['nama_siswa'], lowercase: true) . '_' . url_title($siswa['nis'], lowercase: true) . '.png';
+          $items[] = [
+             'nama' => $siswa['nama_siswa'],
+             'nomor' => $siswa['nis'],
+             'nomor_label' => 'NIS',
+             'kelas' => $siswa['kelas'] ?? ($kelas->kelas ?? ''),
+             'qr_url' => base_url("uploads/qr-siswa/$kelasSlug/$filename"),
+          ];
+       }
+
+       $groupInfo = $idKelas && $kelas ? 'Kelas : ' . $kelas->kelas : 'Semua Kelas';
+       if ($idKelas && $kelas) {
+          $groupInfo .= ' - ' . count($items) . ' Siswa';
+       } else {
+          $groupInfo .= ' - ' . count($items) . ' Siswa';
+       }
+
+       $data = [
+          'title' => 'Cetak QR Siswa',
+          'type' => 'siswa',
+          'groupInfo' => $groupInfo,
+          'items' => $items,
+       ];
+
+       return view('admin/generate-qr/print-qr', $data);
+    }
+
+    public function printQrSiswaSingle($id)
+    {
+       $siswa = (new SiswaModel())->find($id);
+       if (!$siswa) {
+          session()->setFlashdata(['msg' => 'Siswa tidak ditemukan', 'error' => true]);
+          return redirect()->back();
+       }
+
+       $kelasSlug = $this->getKelasJurusanSlug($siswa['id_kelas']) ?? 'tmp';
+       $this->qrCodeFilePath = self::UPLOADS_PATH . "qr-siswa/$kelasSlug/";
+       if (!file_exists($this->qrCodeFilePath)) {
+          mkdir($this->qrCodeFilePath, recursive: true);
+       }
+       $this->qrCode->setForegroundColor($this->foregroundColor);
+       $this->label->setTextColor($this->foregroundColor);
+       $this->generate(
+          nama: $siswa['nama_siswa'],
+          nomor: $siswa['nis'],
+          unique_code: $siswa['unique_code'],
+       );
+
+       $filename = url_title($siswa['nama_siswa'], lowercase: true) . '_' . url_title($siswa['nis'], lowercase: true) . '.png';
+       $items[] = [
+          'nama' => $siswa['nama_siswa'],
+          'nomor' => $siswa['nis'],
+          'nomor_label' => 'NIS',
+          'kelas' => '',
+          'qr_url' => base_url("uploads/qr-siswa/$kelasSlug/$filename"),
+       ];
+
+       $data = [
+          'title' => 'Cetak QR - ' . $siswa['nama_siswa'],
+          'type' => 'siswa',
+          'groupInfo' => $siswa['nama_siswa'] . ' (NIS: ' . $siswa['nis'] . ')',
+          'items' => $items,
+       ];
+
+       return view('admin/generate-qr/print-qr', $data);
+    }
+
+    public function printQrGuruSingle($id)
+    {
+       $guru = (new GuruModel())->find($id);
+       if (!$guru) {
+          session()->setFlashdata(['msg' => 'Data tidak ditemukan', 'error' => true]);
+          return redirect()->back();
+       }
+
+       $this->qrCode->setForegroundColor($this->foregroundColor2);
+       $this->label->setTextColor($this->foregroundColor2);
+       $this->qrCodeFilePath = self::UPLOADS_PATH . 'qr-guru/';
+       if (!file_exists($this->qrCodeFilePath)) {
+          mkdir($this->qrCodeFilePath, recursive: true);
+       }
+       $this->generate(
+          nama: $guru['nama_guru'],
+          nomor: $guru['nuptk'],
+          unique_code: $guru['unique_code'],
+       );
+
+       $filename = url_title($guru['nama_guru'], lowercase: true) . '_' . url_title($guru['nuptk'], lowercase: true) . '.png';
+       $items[] = [
+          'nama' => $guru['nama_guru'],
+          'nomor' => $guru['nuptk'],
+          'nomor_label' => 'NUPTK',
+          'kelas' => '',
+          'qr_url' => base_url('uploads/qr-guru/' . $filename),
+       ];
+
+       $data = [
+          'title' => 'Cetak QR - ' . $guru['nama_guru'],
+          'type' => 'guru',
+          'groupInfo' => $guru['nama_guru'] . ' (NUPTK: ' . $guru['nuptk'] . ')',
+          'items' => $items,
+       ];
+
+       return view('admin/generate-qr/print-qr', $data);
+    }
+
+    public function printQrGuru()
+    {
+       $guruList = (new GuruModel())->getAllGuru();
+
+       $items = [];
+       foreach ($guruList as $guru) {
+          $this->qrCode->setForegroundColor($this->foregroundColor2);
+          $this->label->setTextColor($this->foregroundColor2);
+          $this->qrCodeFilePath = self::UPLOADS_PATH . 'qr-guru/';
+          if (!file_exists($this->qrCodeFilePath)) {
+             mkdir($this->qrCodeFilePath, recursive: true);
+          }
+          $filePath = $this->generate(
+             nama: $guru['nama_guru'],
+             nomor: $guru['nuptk'],
+             unique_code: $guru['unique_code'],
+          );
+
+          $filename = url_title($guru['nama_guru'], lowercase: true) . '_' . url_title($guru['nuptk'], lowercase: true) . '.png';
+          $items[] = [
+             'nama' => $guru['nama_guru'],
+             'nomor' => $guru['nuptk'],
+             'nomor_label' => 'NUPTK',
+             'kelas' => '',
+             'qr_url' => base_url('uploads/qr-guru/' . $filename),
+          ];
+       }
+
+       $data = [
+          'title' => 'Cetak QR Guru',
+          'type' => 'guru',
+          'groupInfo' => 'Semua Guru - ' . count($items) . ' Guru',
+          'items' => $items,
+       ];
+
+       return view('admin/generate-qr/print-qr', $data);
+    }
 }

--- a/app/Controllers/Teacher/QRCode.php
+++ b/app/Controllers/Teacher/QRCode.php
@@ -64,4 +64,23 @@ class QRCode extends BaseController
 
         return $qrGenerator->downloadAllQrSiswa();
     }
+
+    public function print()
+    {
+        $user = user();
+        if (!is_guru()) {
+            return redirect()->to('admin')->with('error', 'Anda bukan Guru.');
+        }
+
+        $kelas = $this->kelasModel->getKelasByWali($user->id_guru);
+
+        if (empty($kelas)) {
+            return redirect()->to('teacher/dashboard')->with('error', 'Kelas belum ditugaskan.');
+        }
+
+        $qrGenerator = new QRGenerator();
+        $qrGenerator->initController($this->request, $this->response, service('logger'));
+
+        return $qrGenerator->printQrSiswa($kelas['id_kelas']);
+    }
 }

--- a/app/Views/admin/data/list-data-guru.php
+++ b/app/Views/admin/data/list-data-guru.php
@@ -21,21 +21,24 @@
                   <td><?= $value['no_hp']; ?></td>
                   <td><?= $value['alamat']; ?></td>
                   <td>
-                     <div class="d-flex justify-content-center">
-                        <a title="Edit" href="<?= base_url('admin/guru/edit/' . $value['id_guru']); ?>" class="btn btn-success p-2" id="<?= $value['nuptk']; ?>">
-                           <i class="material-icons">edit</i>
-                        </a>
-                        <form action="<?= base_url('admin/guru/delete/' . $value['id_guru']); ?>" method="post" class="d-inline">
-                           <?= csrf_field(); ?>
-                           <input type="hidden" name="_method" value="DELETE">
-                           <button title="Delete" onclick="return confirm('Konfirmasi untuk menghapus data');" type="submit" class="btn btn-danger p-2" id="<?= $value['nuptk']; ?>">
-                              <i class="material-icons">delete_forever</i>
-                           </button>
-                        </form>
-                        <a title="Download QR Code" href="<?= base_url('admin/qr/guru/' . $value['id_guru'] . '/download'); ?>" class="btn btn-info p-2">
-                           <i class="material-icons">qr_code</i>
-                        </a>
-                     </div>
+                      <div class="d-flex justify-content-center">
+                         <a title="Edit" href="<?= base_url('admin/guru/edit/' . $value['id_guru']); ?>" class="btn btn-success p-2" id="<?= $value['nuptk']; ?>">
+                            <i class="material-icons">edit</i>
+                         </a>
+                         <form action="<?= base_url('admin/guru/delete/' . $value['id_guru']); ?>" method="post" class="d-inline">
+                            <?= csrf_field(); ?>
+                            <input type="hidden" name="_method" value="DELETE">
+                            <button title="Delete" onclick="return confirm('Konfirmasi untuk menghapus data');" type="submit" class="btn btn-danger p-2" id="<?= $value['nuptk']; ?>">
+                               <i class="material-icons">delete_forever</i>
+                            </button>
+                         </form>
+                         <a title="Download QR Code" href="<?= base_url('admin/qr/guru/' . $value['id_guru'] . '/download'); ?>" class="btn btn-info p-2">
+                            <i class="material-icons">qr_code</i>
+                         </a>
+                         <a title="Cetak QR Code" href="<?= base_url('admin/qr/guru/print-single/' . $value['id_guru']); ?>" class="btn btn-primary p-2" target="_blank">
+                            <i class="material-icons">print</i>
+                         </a>
+                      </div>
                   </td>
                </tr>
             <?php $i++;

--- a/app/Views/admin/data/list-data-siswa.php
+++ b/app/Views/admin/data/list-data-siswa.php
@@ -49,6 +49,11 @@
                            class="btn btn-success p-2">
                            <i class="material-icons">qr_code</i>
                         </a>
+                        <a title="Cetak QR Code"
+                           href="<?= base_url('admin/qr/siswa/print-single/' . $value['id_siswa']); ?>"
+                           class="btn btn-info p-2" target="_blank">
+                           <i class="material-icons">print</i>
+                        </a>
                      </div>
                   </td>
                </tr>

--- a/app/Views/admin/generate-qr/generate-qr.php
+++ b/app/Views/admin/generate-qr/generate-qr.php
@@ -48,39 +48,30 @@
                       <a href="<?= base_url('admin/siswa'); ?>">Lihat data</a>
                     </p>
                     <div class="row px-2">
-                      <div class="col-12 col-xl-6 px-1">
-                        <button onclick="generateAllQrSiswa()" class="btn btn-primary p-2 px-md-4 w-100">
-                          <div class="d-flex align-items-center justify-content-center" style="gap: 12px;">
-                            <div>
-                              <i class="material-icons" style="font-size: 24px;">qr_code</i>
-                            </div>
-                            <div>
-                              <h4 class="d-inline font-weight-bold">Generate All</h4>
-                              <div id="progressSiswa" class="d-none mt-2">
-                                <span id="progressTextSiswa"></span>
-                                <i id="progressSelesaiSiswa" class="material-icons d-none" class="d-none">check</i>
-                                <div class="progress progress-siswa">
-                                  <div id="progressBarSiswa" class="progress-bar my-progress-bar bg-white"
-                                    style="width: 0%;" role="progressbar" aria-valuenow="" aria-valuemin=""
-                                    aria-valuemax=""></div>
-                                </div>
-                              </div>
+                      <div class="col-12 col-xl-4 px-1 mb-2 mb-xl-0">
+                        <button onclick="generateAllQrSiswa()" class="btn btn-primary btn-block p-2 font-weight-bold">
+                          <i class="material-icons align-middle" style="font-size: 20px;">qr_code</i>
+                          <span class="align-middle">Generate All</span>
+                          <div id="progressSiswa" class="d-none mt-1 small">
+                            <span id="progressTextSiswa"></span>
+                            <i id="progressSelesaiSiswa" class="material-icons d-none" style="font-size: 16px;">check</i>
+                            <div class="progress progress-siswa" style="height: 3px;">
+                              <div id="progressBarSiswa" class="progress-bar my-progress-bar bg-white"
+                                style="width: 0%;" role="progressbar"></div>
                             </div>
                           </div>
                         </button>
                       </div>
-                      <div class="col-12 col-xl-6 px-1">
-                        <a href="<?= base_url('admin/qr/siswa/download'); ?>" class="btn btn-primary p-2 px-md-4 w-100">
-                          <div class="d-flex align-items-center justify-content-center" style="gap: 12px;">
-                            <div>
-                              <i class="material-icons" style="font-size: 24px;">cloud_download</i>
-                            </div>
-                            <div>
-                              <div class="text-start">
-                                <h4 class="d-inline font-weight-bold">Download All</h4>
-                              </div>
-                            </div>
-                          </div>
+                      <div class="col-12 col-xl-4 px-1 mb-2 mb-xl-0">
+                        <a href="<?= base_url('admin/qr/siswa/download'); ?>" class="btn btn-primary btn-block p-2 font-weight-bold">
+                          <i class="material-icons align-middle" style="font-size: 20px;">cloud_download</i>
+                          <span class="align-middle">Download All</span>
+                        </a>
+                      </div>
+                      <div class="col-12 col-xl-4 px-1 mb-2 mb-xl-0">
+                        <a href="<?= base_url('admin/qr/siswa/print'); ?>" class="btn btn-primary btn-block p-2 font-weight-bold" target="_blank">
+                          <i class="material-icons align-middle" style="font-size: 20px;">print</i>
+                          <span class="align-middle">Cetak All</span>
                         </a>
                       </div>
                     </div>
@@ -98,43 +89,33 @@
                       </select>
                       <b class="text-danger mt-2" id="textErrorKelas"></b>
                       <div class="row px-2">
-                        <div class="col-12 col-xl-6 px-1">
+                        <div class="col-12 col-md-6 col-xl-4 px-1 mb-2 mb-xl-0">
                           <button type="button" onclick="generateQrSiswaByKelas()"
-                            class="btn btn-primary p-2 px-md-4 w-100">
-                            <div class="d-flex align-items-center justify-content-center" style="gap: 12px;">
-                              <div>
-                                <i class="material-icons" style="font-size: 24px;">qr_code</i>
-                              </div>
-                              <div>
-                                <div class="text-start">
-                                  <h6 class="d-inline">Generate per kelas</h6>
-                                </div>
-                                <div id="progressKelas" class="d-none">
-                                  <span id="progressTextKelas"></span>
-                                  <i id="progressSelesaiKelas" class="material-icons d-none" class="d-none">check</i>
-                                  <div class="progress progress-siswa d-none" id="progressBarBgKelas">
-                                    <div id="progressBarKelas" class="progress-bar my-progress-bar bg-white"
-                                      style="width: 0%;" role="progressbar" aria-valuenow="" aria-valuemin=""
-                                      aria-valuemax=""></div>
-                                  </div>
-                                </div>
+                            class="btn btn-primary btn-block p-2 font-weight-bold">
+                            <i class="material-icons align-middle" style="font-size: 20px;">qr_code</i>
+                            <span class="align-middle">Generate per kelas</span>
+                            <div id="progressKelas" class="d-none mt-1 small">
+                              <span id="progressTextKelas"></span>
+                              <i id="progressSelesaiKelas" class="material-icons d-none" style="font-size: 16px;">check</i>
+                              <div class="progress progress-siswa" style="height: 3px;">
+                                <div id="progressBarKelas" class="progress-bar my-progress-bar bg-white"
+                                  style="width: 0%;" role="progressbar"></div>
                               </div>
                             </div>
                           </button>
                         </div>
-                        <div class="col-12 col-xl-6 px-1">
-                          <button type="submit" class="btn btn-primary p-2 px-md-4 w-100">
-                            <div class="d-flex align-items-center justify-content-center" style="gap: 12px;">
-                              <div>
-                                <i class="material-icons" style="font-size: 24px;">cloud_download</i>
-                              </div>
-                              <div>
-                                <div class="text-start">
-                                  <h6 class="d-inline">Download Per Kelas</h6>
-                                </div>
-                              </div>
-                            </div>
+                        <div class="col-12 col-md-6 col-xl-4 px-1 mb-2 mb-xl-0">
+                          <button type="submit" class="btn btn-primary btn-block p-2 font-weight-bold">
+                            <i class="material-icons align-middle" style="font-size: 20px;">cloud_download</i>
+                            <span class="align-middle">Download Per Kelas</span>
                           </button>
+                        </div>
+                        <div class="col-12 col-md-6 col-xl-4 px-1 mb-2 mb-xl-0">
+                          <a id="printKelasLink" href="#"
+                            class="btn btn-primary btn-block p-2 font-weight-bold" target="_blank">
+                            <i class="material-icons align-middle" style="font-size: 20px;">print</i>
+                            <span class="align-middle">Cetak Per Kelas</span>
+                          </a>
                         </div>
                       </div>
                     </form>
@@ -155,41 +136,30 @@
                       <a href="<?= base_url('admin/guru'); ?>" class="text-success">Lihat data</a>
                     </p>
                     <div class="row px-2">
-                      <div class="col-12 col-xl-6 px-1">
-                        <button onclick="generateAllQrGuru()" class="btn btn-success p-2 px-md-4 w-100">
-                          <div class="d-flex align-items-center justify-content-center" style="gap: 12px;">
-                            <div>
-                              <i class="material-icons" style="font-size: 24px;">qr_code</i>
-                            </div>
-                            <div>
-                              <h4 class="d-inline font-weight-bold">Generate All</h4>
-                              <div>
-                                <div id="progressGuru" class="d-none mt-2">
-                                  <span id="progressTextGuru"></span>
-                                  <i id="progressSelesaiGuru" class="material-icons d-none" class="d-none">check</i>
-                                  <div class="progress progress-guru">
-                                    <div id="progressBarGuru" class="progress-bar my-progress-bar bg-white"
-                                      style="width: 0%;" role="progressbar" aria-valuenow="" aria-valuemin=""
-                                      aria-valuemax=""></div>
-                                  </div>
-                                </div>
-                              </div>
+                      <div class="col-12 col-xl-4 px-1 mb-2 mb-xl-0">
+                        <button onclick="generateAllQrGuru()" class="btn btn-success btn-block p-2 font-weight-bold">
+                          <i class="material-icons align-middle" style="font-size: 20px;">qr_code</i>
+                          <span class="align-middle">Generate All</span>
+                          <div id="progressGuru" class="d-none mt-1 small">
+                            <span id="progressTextGuru"></span>
+                            <i id="progressSelesaiGuru" class="material-icons d-none" style="font-size: 16px;">check</i>
+                            <div class="progress progress-guru" style="height: 3px;">
+                              <div id="progressBarGuru" class="progress-bar my-progress-bar bg-white"
+                                style="width: 0%;" role="progressbar"></div>
                             </div>
                           </div>
                         </button>
                       </div>
-                      <div class="col-12 col-xl-6 px-1">
-                        <a href="<?= base_url('admin/qr/guru/download'); ?>" class="btn btn-success p-2 px-md-4 w-100">
-                          <div class="d-flex align-items-center justify-content-center" style="gap: 12px;">
-                            <div>
-                              <i class="material-icons" style="font-size: 24px;">cloud_download</i>
-                            </div>
-                            <div>
-                              <div class="text-start">
-                                <h4 class="d-inline font-weight-bold">Download All</h4>
-                              </div>
-                            </div>
-                          </div>
+                      <div class="col-12 col-xl-4 px-1 mb-2 mb-xl-0">
+                        <a href="<?= base_url('admin/qr/guru/download'); ?>" class="btn btn-success btn-block p-2 font-weight-bold">
+                          <i class="material-icons align-middle" style="font-size: 20px;">cloud_download</i>
+                          <span class="align-middle">Download All</span>
+                        </a>
+                      </div>
+                      <div class="col-12 col-xl-4 px-1 mb-2 mb-xl-0">
+                        <a href="<?= base_url('admin/qr/guru/print'); ?>" class="btn btn-success btn-block p-2 font-weight-bold" target="_blank">
+                          <i class="material-icons align-middle" style="font-size: 20px;">print</i>
+                          <span class="align-middle">Cetak All</span>
                         </a>
                       </div>
                     </div>
@@ -351,6 +321,15 @@
       }
     });
   }
+
+  $('#kelasSelect').on('change', function() {
+    var idKelas = $(this).val();
+    if (idKelas) {
+      $('#printKelasLink').attr('href', '<?= base_url('admin/qr/siswa/print'); ?>/' + idKelas);
+    } else {
+      $('#printKelasLink').attr('href', '#');
+    }
+  });
 
   function generateAllQrGuru() {
     var i = 1;

--- a/app/Views/admin/generate-qr/print-qr.php
+++ b/app/Views/admin/generate-qr/print-qr.php
@@ -1,0 +1,135 @@
+<!DOCTYPE html>
+<html lang="id">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Cetak QR Code - <?= esc($title ?? '') ?></title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+
+    body {
+      font-family: 'Segoe UI', Arial, sans-serif;
+      background: #fff;
+      padding: 20px;
+    }
+
+    .no-print { display: none; }
+
+    .header {
+      text-align: center;
+      margin-bottom: 24px;
+    }
+
+    .header h2 {
+      font-size: 18px;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 1px;
+    }
+
+    .header p {
+      font-size: 13px;
+      color: #555;
+      margin-top: 4px;
+    }
+
+    .qr-grid {
+      display: grid;
+      grid-template-columns: repeat(4, 1fr);
+      gap: 12px;
+    }
+
+    .qr-card {
+      border: 1px solid #ddd;
+      border-radius: 6px;
+      padding: 12px;
+      text-align: center;
+      page-break-inside: avoid;
+      break-inside: avoid;
+    }
+
+    .qr-card img {
+      width: 100%;
+      max-width: 140px;
+      height: auto;
+      display: block;
+      margin: 0 auto 8px;
+    }
+
+    .qr-card .name {
+      font-size: 12px;
+      font-weight: 700;
+      line-height: 1.3;
+      margin-bottom: 2px;
+    }
+
+    .qr-card .nip {
+      font-size: 10px;
+      color: #666;
+    }
+
+    .qr-card .kelas-label {
+      font-size: 10px;
+      color: #888;
+      margin-top: 2px;
+    }
+
+    @media print {
+      body { padding: 10px; }
+      .header { margin-bottom: 16px; }
+      .qr-grid { gap: 8px; }
+      .qr-card { padding: 8px; border: 1px solid #ccc; }
+      .qr-card img { max-width: 120px; }
+      .qr-card .name { font-size: 11px; }
+      .qr-card .nip { font-size: 9px; }
+    }
+
+    @media screen {
+      body { max-width: 1000px; margin: 0 auto; }
+      .no-print {
+        display: block;
+        text-align: center;
+        margin-bottom: 20px;
+      }
+      .no-print button {
+        padding: 10px 28px;
+        font-size: 14px;
+        font-weight: 600;
+        background: #9c27b0;
+        color: #fff;
+        border: none;
+        border-radius: 6px;
+        cursor: pointer;
+      }
+      .no-print button:hover { background: #7b1fa2; }
+    }
+  </style>
+</head>
+<body>
+  <div class="no-print">
+    <button onclick="window.print()">Cetak QR Code</button>
+  </div>
+
+  <div class="header">
+    <h2>Kartu QR Code <?= esc($type === 'siswa' ? 'Siswa' : 'Guru') ?></h2>
+    <p><?= esc($groupInfo) ?></p>
+  </div>
+
+  <div class="qr-grid">
+    <?php foreach ($items as $item): ?>
+      <div class="qr-card">
+        <img src="<?= esc($item['qr_url']) ?>" alt="QR <?= esc($item['nama']) ?>">
+        <div class="name"><?= esc($item['nama']) ?></div>
+        <div class="nip"><?= esc($item['nomor_label']) ?>: <?= esc($item['nomor']) ?></div>
+        <?php if (!empty($item['kelas'])): ?>
+          <div class="kelas-label"><?= esc($item['kelas']) ?></div>
+        <?php endif; ?>
+      </div>
+    <?php endforeach; ?>
+  </div>
+
+  <script>
+    window.print();
+  </script>
+</body>
+</html>

--- a/app/Views/teacher/qr_code.php
+++ b/app/Views/teacher/qr_code.php
@@ -39,38 +39,30 @@
                     <h4 class="text-primary"><b>Data Siswa</b></h4>
                     <p>Total jumlah siswa : <b><?= count($siswa); ?></b></p>
                     <div class="row px-2">
-                      <div class="col-12 col-xl-4 px-1">
-                        <button onclick="generateAllQrSiswa()" class="btn btn-primary p-2 px-md-4 w-100">
-                          <div class="d-flex align-items-center justify-content-center" style="gap: 12px;">
-                            <div>
-                              <i class="material-icons" style="font-size: 24px;">qr_code</i>
-                            </div>
-                            <div>
-                              <h4 class="d-inline font-weight-bold">Generate All</h4>
-                              <div id="progressSiswa" class="d-none mt-2">
-                                <span id="progressTextSiswa"></span>
-                                <i id="progressSelesaiSiswa" class="material-icons d-none">check</i>
-                                <div class="progress progress-siswa">
-                                  <div id="progressBarSiswa" class="progress-bar my-progress-bar bg-white" style="width: 0%;" role="progressbar" aria-valuenow="" aria-valuemin="" aria-valuemax="">
-                                  </div>
-                                </div>
-                              </div>
+                      <div class="col-12 col-xl-4 px-1 mb-2 mb-xl-0">
+                        <button onclick="generateAllQrSiswa()" class="btn btn-primary btn-block p-2 font-weight-bold">
+                          <i class="material-icons align-middle" style="font-size: 20px;">qr_code</i>
+                          <span class="align-middle">Generate All</span>
+                          <div id="progressSiswa" class="d-none mt-1 small">
+                            <span id="progressTextSiswa"></span>
+                            <i id="progressSelesaiSiswa" class="material-icons d-none" style="font-size: 16px;">check</i>
+                            <div class="progress progress-siswa" style="height: 3px;">
+                              <div id="progressBarSiswa" class="progress-bar my-progress-bar bg-white"
+                                style="width: 0%;" role="progressbar"></div>
                             </div>
                           </div>
                         </button>
                       </div>
-                      <div class="col-12 col-xl-4 px-1">
-                        <a href="<?= base_url('teacher/qr/download'); ?>" class="btn btn-success p-2 px-md-4 w-100">
-                          <div class="d-flex align-items-center justify-content-center h-100" style="gap: 12px;">
-                            <div>
-                              <i class="material-icons" style="font-size: 24px;">cloud_download</i>
-                            </div>
-                            <div>
-                              <div class="text-start">
-                                <h4 class="d-inline font-weight-bold">Download All (.zip)</h4>
-                              </div>
-                            </div>
-                          </div>
+                      <div class="col-12 col-xl-4 px-1 mb-2 mb-xl-0">
+                        <a href="<?= base_url('teacher/qr/download'); ?>" class="btn btn-success btn-block p-2 font-weight-bold">
+                          <i class="material-icons align-middle" style="font-size: 20px;">cloud_download</i>
+                          <span class="align-middle">Download All (.zip)</span>
+                        </a>
+                      </div>
+                      <div class="col-12 col-xl-4 px-1 mb-2 mb-xl-0">
+                        <a href="<?= base_url('teacher/qr/print'); ?>" class="btn btn-primary btn-block p-2 font-weight-bold" target="_blank">
+                          <i class="material-icons align-middle" style="font-size: 20px;">print</i>
+                          <span class="align-middle">Cetak QR</span>
                         </a>
                       </div>
                     </div>
@@ -93,6 +85,9 @@
                               <td class="text-center">
                                 <a href="<?= base_url('admin/qr/siswa/' . $s['id_siswa'] . '/download'); ?>" class="btn btn-info btn-sm">
                                   <i class="material-icons">download</i> Download QR
+                                </a>
+                                <a href="<?= base_url('admin/qr/siswa/print-single/' . $s['id_siswa']); ?>" class="btn btn-primary btn-sm" target="_blank">
+                                  <i class="material-icons">print</i> Cetak
                                 </a>
                               </td>
                             </tr>


### PR DESCRIPTION
## Deskripsi
Menambahkan fitur cetak QR Code langsung dari panel admin (issue #114).

## Perubahan
- **Halaman cetak baru** (`print-qr.php`) — grid 4 kolom, print-optimized dengan @media print CSS, auto window.print()
- **Controller** — `printQrSiswa()`, `printQrGuru()` untuk bulk, `printQrSiswaSingle()`, `printQrGuruSingle()` untuk individual
- **Routes** — `admin/qr/siswa/print`, `admin/qr/siswa/print/{id_kelas}`, `admin/qr/siswa/print-single/{id}`, `admin/qr/guru/print`, `admin/qr/guru/print-single/{id}`, `teacher/qr/print`
- **Tombol cetak** di halaman Generate QR, Data Siswa, Data Guru, dan QR Code Siswa (teacher)
- **Perbaikan layout button** — lebih kompak, tidak overflow di 3 kolom

Closes #114