### PR TITLE
fix: resolve QR generation (PHP 7.4) and CSV import bugs

### DIFF
--- a/app/Common.php
+++ b/app/Common.php
@@ -290,7 +290,7 @@ if (!function_exists('getCSVInputValue')) {
     function getCSVInputValue($array, $key, $dataType = 'string')
     {
         if (!empty($array)) {
-            if (!empty($array[$key])) {
+            if (isset($array[$key]) && $array[$key] !== '') {
                 return $array[$key];
             }
         }

--- a/app/Controllers/Admin/DataGuru.php
+++ b/app/Controllers/Admin/DataGuru.php
@@ -248,16 +248,24 @@ class DataGuru extends BaseController
       $txtFileName = inputPost('txtFileName');
       $index = inputPost('index');
       $guru = $this->guruModel->importCSVItem($txtFileName, $index);
-      if (!empty($guru)) {
+
+      if (!empty($guru) && !isset($guru['status'])) {
          $data = [
             'result' => 1,
             'guru' => $guru,
             'index' => $index
          ];
          echo json_encode($data);
+      } elseif (isset($guru['status']) && $guru['status'] === 'duplicate') {
+         echo json_encode([
+            'result' => 2,
+            'message' => $guru['message'],
+            'index' => $index
+         ]);
       } else {
          $data = [
             'result' => 0,
+            'message' => $guru['message'] ?? 'Gagal import data',
             'index' => $index
          ];
          echo json_encode($data);

--- a/app/Controllers/Admin/DataSiswa.php
+++ b/app/Controllers/Admin/DataSiswa.php
@@ -295,16 +295,24 @@ class DataSiswa extends BaseController
       $txtFileName = inputPost('txtFileName');
       $index = inputPost('index');
       $siswa = $this->siswaModel->importCSVItem($txtFileName, $index);
-      if (!empty($siswa)) {
+
+      if (!empty($siswa) && !isset($siswa['status'])) {
          $data = [
             'result' => 1,
             'siswa' => $siswa,
             'index' => $index
          ];
          echo json_encode($data);
+      } elseif (isset($siswa['status']) && $siswa['status'] === 'duplicate') {
+         echo json_encode([
+            'result' => 2,
+            'message' => $siswa['message'],
+            'index' => $index
+         ]);
       } else {
          $data = [
             'result' => 0,
+            'message' => $siswa['message'] ?? 'Gagal import data',
             'index' => $index
          ];
          echo json_encode($data);

--- a/app/Controllers/Admin/QRGenerator.php
+++ b/app/Controllers/Admin/QRGenerator.php
@@ -45,9 +45,10 @@ class QRGenerator extends BaseController
       $this->foregroundColor2 = new Color(28, 101, 90);
       $this->backgroundColor = new Color(255, 255, 255);
 
-      if (boolval(env('QR_LOGO'))) {
+      if (filter_var(env('QR_LOGO'), FILTER_VALIDATE_BOOLEAN)) {
          // Create logo
-         $logo = (new \Config\School)::$generalSettings->logo;
+          $settings = (new \Config\School)::$generalSettings ?? null;
+          $logo = ($settings ? ($settings->logo ?? false) : false);
          if (empty($logo) || !file_exists(FCPATH . $logo)) {
             $logo = 'assets/img/logo_sekolah.jpg';
          }
@@ -84,7 +85,7 @@ class QRGenerator extends BaseController
    {
       $this->qrCodeFilePath = $qrCodeFilePath;
       if (!file_exists($this->qrCodeFilePath))
-         mkdir($this->qrCodeFilePath, recursive: true);
+         mkdir($this->qrCodeFilePath, 0777, true);
    }
 
    public function generateQrSiswa()
@@ -97,16 +98,20 @@ class QRGenerator extends BaseController
       $this->qrCodeFilePath .= "qr-siswa/$kelas/";
 
       if (!file_exists($this->qrCodeFilePath)) {
-         mkdir($this->qrCodeFilePath, recursive: true);
+         mkdir($this->qrCodeFilePath, 0777, true);
       }
 
-      $this->generate(
-         unique_code: $this->request->getVar('unique_code'),
-         nama: $this->request->getVar('nama'),
-         nomor: $this->request->getVar('nomor')
-      );
-
-      return $this->response->setJSON(true);
+      try {
+         $this->generate(
+            unique_code: $this->request->getVar('unique_code'),
+            nama: $this->request->getVar('nama'),
+            nomor: $this->request->getVar('nomor')
+         );
+         return $this->response->setJSON(true);
+      } catch (\Throwable $th) {
+         log_message('error', 'QR Siswa generate failed: ' . $th->getMessage());
+         return $this->response->setJSON(false);
+      }
    }
 
    public function generateQrGuru()
@@ -117,16 +122,20 @@ class QRGenerator extends BaseController
       $this->qrCodeFilePath .= 'qr-guru/';
 
       if (!file_exists($this->qrCodeFilePath)) {
-         mkdir($this->qrCodeFilePath, recursive: true);
+         mkdir($this->qrCodeFilePath, 0777, true);
       }
 
-      $this->generate(
-         unique_code: $this->request->getVar('unique_code'),
-         nama: $this->request->getVar('nama'),
-         nomor: $this->request->getVar('nomor')
-      );
-
-      return $this->response->setJSON(true);
+      try {
+         $this->generate(
+            unique_code: $this->request->getVar('unique_code'),
+            nama: $this->request->getVar('nama'),
+            nomor: $this->request->getVar('nomor')
+         );
+         return $this->response->setJSON(true);
+      } catch (\Throwable $th) {
+         log_message('error', 'QR Guru generate failed: ' . $th->getMessage());
+         return $this->response->setJSON(false);
+      }
    }
 
    public function generate($nama, $nomor, $unique_code)
@@ -183,7 +192,7 @@ class QRGenerator extends BaseController
          $kelas = $this->getKelasJurusanSlug($siswa['id_kelas']) ?? 'tmp';
          $this->qrCodeFilePath .= "qr-siswa/$kelas/";
          if (!file_exists($this->qrCodeFilePath)) {
-            mkdir($this->qrCodeFilePath, recursive: true);
+            mkdir($this->qrCodeFilePath, 0777, true);
          }
          $filePath = $this->generate(
             nama: $siswa['nama_siswa'],
@@ -200,7 +209,7 @@ class QRGenerator extends BaseController
          $this->label->setTextColor($this->foregroundColor2);
          $this->qrCodeFilePath .= 'qr-guru/';
          if (!file_exists($this->qrCodeFilePath)) {
-            mkdir($this->qrCodeFilePath, recursive: true);
+            mkdir($this->qrCodeFilePath, 0777, true);
          }
          $filePath = $this->generate(
             nama: $guru['nama_guru'],
@@ -368,26 +377,27 @@ class QRGenerator extends BaseController
           $siswaList = $siswaModel->getAllSiswaWithKelas();
        }
 
-       $items = [];
-       foreach ($siswaList as $siswa) {
-          $idKelasSiswa = $siswa['id_kelas'];
-          if (!isset($slugCache[$idKelasSiswa])) {
-             $slugCache[$idKelasSiswa] = $this->getKelasJurusanSlug($idKelasSiswa) ?? 'tmp';
-          }
-          $kelasSlug = $slugCache[$idKelasSiswa];
-          $this->qrCodeFilePath = self::UPLOADS_PATH . "qr-siswa/$kelasSlug/";
-          if (!file_exists($this->qrCodeFilePath)) {
-             mkdir($this->qrCodeFilePath, recursive: true);
-          }
-          $this->qrCode->setForegroundColor($this->foregroundColor);
-          $this->label->setTextColor($this->foregroundColor);
-          $filePath = $this->generate(
-             nama: $siswa['nama_siswa'],
-             nomor: $siswa['nis'],
-             unique_code: $siswa['unique_code'],
-          );
+      $items = [];
+      foreach ($siswaList as $siswa) {
+         $idKelasSiswa = $siswa['id_kelas'];
+         if (!isset($slugCache[$idKelasSiswa])) {
+            $slugCache[$idKelasSiswa] = $this->getKelasJurusanSlug($idKelasSiswa) ?? 'tmp';
+         }
+         $kelasSlug = $slugCache[$idKelasSiswa];
+         $this->qrCodeFilePath = self::UPLOADS_PATH . "qr-siswa/$kelasSlug/";
+         if (!file_exists($this->qrCodeFilePath)) {
+            mkdir($this->qrCodeFilePath, 0777, true);
+         }
+         $this->qrCode->setForegroundColor($this->foregroundColor);
+         $this->label->setTextColor($this->foregroundColor);
+         $filePath = $this->generate(
+            nama: $siswa['nama_siswa'],
+            nomor: $siswa['nis'],
+            unique_code: $siswa['unique_code'],
+         );
 
-          $filename = url_title($siswa['nama_siswa'], lowercase: true) . '_' . url_title($siswa['nis'], lowercase: true) . '.png';
+         $fileExt = $this->getFileExtension();
+         $filename = url_title($siswa['nama_siswa'], lowercase: true) . '_' . url_title($siswa['nis'], lowercase: true) . '.' . $fileExt;
           $items[] = [
              'nama' => $siswa['nama_siswa'],
              'nomor' => $siswa['nis'],
@@ -414,104 +424,114 @@ class QRGenerator extends BaseController
        return view('admin/generate-qr/print-qr', $data);
     }
 
-    public function printQrSiswaSingle($id)
-    {
-       $siswa = (new SiswaModel())->find($id);
-       if (!$siswa) {
-          session()->setFlashdata(['msg' => 'Siswa tidak ditemukan', 'error' => true]);
-          return redirect()->back();
-       }
+   protected function getFileExtension(): string
+   {
+      return $this->writer instanceof SvgWriter ? 'svg' : 'png';
+   }
 
-       $kelasSlug = $this->getKelasJurusanSlug($siswa['id_kelas']) ?? 'tmp';
-       $this->qrCodeFilePath = self::UPLOADS_PATH . "qr-siswa/$kelasSlug/";
-       if (!file_exists($this->qrCodeFilePath)) {
-          mkdir($this->qrCodeFilePath, recursive: true);
-       }
-       $this->qrCode->setForegroundColor($this->foregroundColor);
-       $this->label->setTextColor($this->foregroundColor);
-       $this->generate(
-          nama: $siswa['nama_siswa'],
-          nomor: $siswa['nis'],
-          unique_code: $siswa['unique_code'],
-       );
+   public function printQrSiswaSingle($id)
+   {
+      $siswa = (new SiswaModel())->find($id);
+      if (!$siswa) {
+         session()->setFlashdata(['msg' => 'Siswa tidak ditemukan', 'error' => true]);
+         return redirect()->back();
+      }
 
-       $filename = url_title($siswa['nama_siswa'], lowercase: true) . '_' . url_title($siswa['nis'], lowercase: true) . '.png';
-       $items[] = [
-          'nama' => $siswa['nama_siswa'],
-          'nomor' => $siswa['nis'],
-          'nomor_label' => 'NIS',
-          'kelas' => '',
-          'qr_url' => base_url("uploads/qr-siswa/$kelasSlug/$filename"),
-       ];
+      $kelasSlug = $this->getKelasJurusanSlug($siswa['id_kelas']) ?? 'tmp';
+      $this->qrCodeFilePath = self::UPLOADS_PATH . "qr-siswa/$kelasSlug/";
+      if (!file_exists($this->qrCodeFilePath)) {
+         mkdir($this->qrCodeFilePath, 0777, true);
+      }
+      $this->qrCode->setForegroundColor($this->foregroundColor);
+      $this->label->setTextColor($this->foregroundColor);
+      $this->generate(
+         nama: $siswa['nama_siswa'],
+         nomor: $siswa['nis'],
+         unique_code: $siswa['unique_code'],
+      );
 
-       $data = [
-          'title' => 'Cetak QR - ' . $siswa['nama_siswa'],
-          'type' => 'siswa',
-          'groupInfo' => $siswa['nama_siswa'] . ' (NIS: ' . $siswa['nis'] . ')',
-          'items' => $items,
-       ];
+      $fileExt = $this->getFileExtension();
+      $filename = url_title($siswa['nama_siswa'], lowercase: true) . '_' . url_title($siswa['nis'], lowercase: true) . '.' . $fileExt;
+      $items = [];
+      $items[] = [
+         'nama' => $siswa['nama_siswa'],
+         'nomor' => $siswa['nis'],
+         'nomor_label' => 'NIS',
+         'kelas' => '',
+         'qr_url' => base_url("uploads/qr-siswa/$kelasSlug/$filename"),
+      ];
 
-       return view('admin/generate-qr/print-qr', $data);
-    }
+      $data = [
+         'title' => 'Cetak QR - ' . $siswa['nama_siswa'],
+         'type' => 'siswa',
+         'groupInfo' => $siswa['nama_siswa'] . ' (NIS: ' . $siswa['nis'] . ')',
+         'items' => $items,
+      ];
 
-    public function printQrGuruSingle($id)
-    {
-       $guru = (new GuruModel())->find($id);
-       if (!$guru) {
-          session()->setFlashdata(['msg' => 'Data tidak ditemukan', 'error' => true]);
-          return redirect()->back();
-       }
+      return view('admin/generate-qr/print-qr', $data);
+   }
 
-       $this->qrCode->setForegroundColor($this->foregroundColor2);
-       $this->label->setTextColor($this->foregroundColor2);
-       $this->qrCodeFilePath = self::UPLOADS_PATH . 'qr-guru/';
-       if (!file_exists($this->qrCodeFilePath)) {
-          mkdir($this->qrCodeFilePath, recursive: true);
-       }
-       $this->generate(
-          nama: $guru['nama_guru'],
-          nomor: $guru['nuptk'],
-          unique_code: $guru['unique_code'],
-       );
+   public function printQrGuruSingle($id)
+   {
+      $guru = (new GuruModel())->find($id);
+      if (!$guru) {
+         session()->setFlashdata(['msg' => 'Data tidak ditemukan', 'error' => true]);
+         return redirect()->back();
+      }
 
-       $filename = url_title($guru['nama_guru'], lowercase: true) . '_' . url_title($guru['nuptk'], lowercase: true) . '.png';
-       $items[] = [
-          'nama' => $guru['nama_guru'],
-          'nomor' => $guru['nuptk'],
-          'nomor_label' => 'NUPTK',
-          'kelas' => '',
-          'qr_url' => base_url('uploads/qr-guru/' . $filename),
-       ];
+      $this->qrCode->setForegroundColor($this->foregroundColor2);
+      $this->label->setTextColor($this->foregroundColor2);
+      $this->qrCodeFilePath = self::UPLOADS_PATH . 'qr-guru/';
+      if (!file_exists($this->qrCodeFilePath)) {
+         mkdir($this->qrCodeFilePath, 0777, true);
+      }
+      $this->generate(
+         nama: $guru['nama_guru'],
+         nomor: $guru['nuptk'],
+         unique_code: $guru['unique_code'],
+      );
 
-       $data = [
-          'title' => 'Cetak QR - ' . $guru['nama_guru'],
-          'type' => 'guru',
-          'groupInfo' => $guru['nama_guru'] . ' (NUPTK: ' . $guru['nuptk'] . ')',
-          'items' => $items,
-       ];
+      $fileExt = $this->getFileExtension();
+      $filename = url_title($guru['nama_guru'], lowercase: true) . '_' . url_title($guru['nuptk'], lowercase: true) . '.' . $fileExt;
+      $items = [];
+      $items[] = [
+         'nama' => $guru['nama_guru'],
+         'nomor' => $guru['nuptk'],
+         'nomor_label' => 'NUPTK',
+         'kelas' => '',
+         'qr_url' => base_url('uploads/qr-guru/' . $filename),
+      ];
 
-       return view('admin/generate-qr/print-qr', $data);
-    }
+      $data = [
+         'title' => 'Cetak QR - ' . $guru['nama_guru'],
+         'type' => 'guru',
+         'groupInfo' => $guru['nama_guru'] . ' (NUPTK: ' . $guru['nuptk'] . ')',
+         'items' => $items,
+      ];
 
-    public function printQrGuru()
-    {
-       $guruList = (new GuruModel())->getAllGuru();
+      return view('admin/generate-qr/print-qr', $data);
+   }
 
-       $items = [];
-       foreach ($guruList as $guru) {
-          $this->qrCode->setForegroundColor($this->foregroundColor2);
-          $this->label->setTextColor($this->foregroundColor2);
-          $this->qrCodeFilePath = self::UPLOADS_PATH . 'qr-guru/';
-          if (!file_exists($this->qrCodeFilePath)) {
-             mkdir($this->qrCodeFilePath, recursive: true);
-          }
-          $filePath = $this->generate(
-             nama: $guru['nama_guru'],
-             nomor: $guru['nuptk'],
-             unique_code: $guru['unique_code'],
-          );
+     public function printQrGuru()
+     {
+        $guruList = (new GuruModel())->getAllGuru();
 
-          $filename = url_title($guru['nama_guru'], lowercase: true) . '_' . url_title($guru['nuptk'], lowercase: true) . '.png';
+        $items = [];
+        foreach ($guruList as $guru) {
+           $this->qrCode->setForegroundColor($this->foregroundColor2);
+           $this->label->setTextColor($this->foregroundColor2);
+           $this->qrCodeFilePath = self::UPLOADS_PATH . 'qr-guru/';
+           if (!file_exists($this->qrCodeFilePath)) {
+              mkdir($this->qrCodeFilePath, 0777, true);
+           }
+           $filePath = $this->generate(
+              nama: $guru['nama_guru'],
+              nomor: $guru['nuptk'],
+              unique_code: $guru['unique_code'],
+           );
+
+           $fileExt = $this->getFileExtension();
+           $filename = url_title($guru['nama_guru'], lowercase: true) . '_' . url_title($guru['nuptk'], lowercase: true) . '.' . $fileExt;
           $items[] = [
              'nama' => $guru['nama_guru'],
              'nomor' => $guru['nuptk'],

--- a/app/Models/GuruModel.php
+++ b/app/Models/GuruModel.php
@@ -76,9 +76,9 @@ class GuruModel extends Model
             if (empty($fields)) {
                $fields = $row;
                // Remove BOM from the first element if present
-               if (isset($fields[0])) {
-                  $fields[0] = preg_replace('/[\x00-\x1F\x80-\xFF]/', '', $fields[0]);
-               }
+                if (isset($fields[0])) {
+                   $fields[0] = preg_replace('/^\xEF\xBB\xBF/', '', $fields[0]);
+                }
                // Trim all fields
                $fields = array_map('trim', $fields);
                continue;
@@ -119,36 +119,39 @@ class GuruModel extends Model
          $i = 1;
          foreach ($array as $item) {
             if ($i == $index) {
-               $nuptk = getCSVInputValue($item, 'nuptk');
-               $nama = getCSVInputValue($item, 'nama_guru');
-               $noHp = getCSVInputValue($item, 'no_hp');
+               $data = array();
+               $data['nuptk'] = getCSVInputValue($item, 'nuptk');
+               $data['nama_guru'] = getCSVInputValue($item, 'nama_guru');
+               $data['alamat'] = getCSVInputValue($item, 'alamat');
+               $data['no_hp'] = getCSVInputValue($item, 'no_hp');
+               $data['unique_code'] = sha1($data['nama_guru'] . md5($data['nuptk'] . $data['nama_guru'] . $data['no_hp'])) . substr(sha1($data['nuptk'] . rand(0, 100)), 0, 24);
+
+               if (empty($data['nuptk']) || empty($data['nama_guru'])) {
+                  return ['status' => 'error', 'message' => 'NUPTK dan Nama Guru wajib diisi'];
+               }
+
+               $nuptkExists = $this->where('nuptk', $data['nuptk'])->countAllResults();
+               if ($nuptkExists > 0) {
+                  return ['status' => 'duplicate', 'message' => 'NUPTK ' . $data['nuptk'] . ' sudah terdaftar'];
+               }
 
                $jk = strtolower(getCSVInputValue($item, 'jenis_kelamin'));
                if (in_array($jk, ['l', 'laki-laki', 'laki laki', 'laki'])) {
-                  $jk = 'Laki-laki';
+                  $data['jenis_kelamin'] = 'Laki-laki';
                } elseif (in_array($jk, ['p', 'perempuan', 'wanita'])) {
-                  $jk = 'Perempuan';
+                  $data['jenis_kelamin'] = 'Perempuan';
                } else {
-                  $jk = 'Laki-laki'; // Default jika tidak dikenal
+                  return ['status' => 'error', 'message' => 'Jenis kelamin tidak dikenal: ' . $jk];
                }
-
-               $data = array();
-               $data['nuptk'] = $nuptk;
-               $data['nama_guru'] = $nama;
-               $data['jenis_kelamin'] = $jk;
-               $data['alamat'] = getCSVInputValue($item, 'alamat');
-               $data['no_hp'] = $noHp;
-               // Logic from createGuru
-               $data['unique_code'] = sha1($nama . md5($nuptk . $nama . $noHp)) . substr(sha1($nuptk . rand(0, 100)), 0, 24);
 
                if ($this->insert($data)) {
                   return $data;
                }
-               return false;
+               return ['status' => 'error', 'message' => 'Gagal menyimpan data'];
             }
             $i++;
          }
       }
-      return false;
+      return ['status' => 'error', 'message' => 'Data CSV tidak ditemukan'];
    }
 }

--- a/app/Models/SiswaModel.php
+++ b/app/Models/SiswaModel.php
@@ -143,10 +143,10 @@ class SiswaModel extends Model
          while (($row = fgetcsv($handle)) !== false) {
             if (empty($fields)) {
                $fields = $row;
-               // Remove BOM from the first element if present
-               if (isset($fields[0])) {
-                  $fields[0] = preg_replace('/[\x00-\x1F\x80-\xFF]/', '', $fields[0]);
-               }
+                // Remove BOM from the first element if present
+                if (isset($fields[0])) {
+                   $fields[0] = preg_replace('/^\xEF\xBB\xBF/', '', $fields[0]);
+                }
                // Trim all fields
                $fields = array_map('trim', $fields);
                continue;
@@ -187,32 +187,47 @@ class SiswaModel extends Model
          $i = 1;
          foreach ($array as $item) {
             if ($i == $index) {
-               $jk = strtolower(getCSVInputValue($item, 'jenis_kelamin'));
-               if (in_array($jk, ['l', 'laki-laki', 'laki laki', 'laki'])) {
-                  $jk = 'Laki-laki';
-               } elseif (in_array($jk, ['p', 'perempuan', 'wanita'])) {
-                  $jk = 'Perempuan';
-               } else {
-                  $jk = 'Laki-laki'; // Default jika tidak dikenal
-               }
-
                $data = array();
-               $data['nis'] = getCSVInputValue($item, 'nis', 'int');
+               $data['nis'] = getCSVInputValue($item, 'nis');
                $data['nama_siswa'] = getCSVInputValue($item, 'nama_siswa');
-               $data['id_kelas'] = getCSVInputValue($item, 'id_kelas', 'int');
-               $data['jenis_kelamin'] = $jk;
+               $data['id_kelas'] = getCSVInputValue($item, 'id_kelas');
                $data['no_hp'] = getCSVInputValue($item, 'no_hp');
                $data['unique_code'] = generateToken();
+
+               if (empty($data['nis']) || empty($data['nama_siswa']) || empty($data['id_kelas'])) {
+                  return ['status' => 'error', 'message' => 'NIS, Nama, dan Kelas wajib diisi'];
+               }
+
+               $kelasExists = $this->db->table('tb_kelas')
+                  ->where('id_kelas', $data['id_kelas'])
+                  ->countAllResults();
+               if (!$kelasExists) {
+                  return ['status' => 'error', 'message' => 'ID Kelas ' . $data['id_kelas'] . ' tidak ditemukan'];
+               }
+
+               $nisExists = $this->where('nis', $data['nis'])->countAllResults();
+               if ($nisExists > 0) {
+                  return ['status' => 'duplicate', 'message' => 'NIS ' . $data['nis'] . ' sudah terdaftar'];
+               }
+
+               $jk = strtolower(getCSVInputValue($item, 'jenis_kelamin'));
+               if (in_array($jk, ['l', 'laki-laki', 'laki laki', 'laki'])) {
+                  $data['jenis_kelamin'] = 'Laki-laki';
+               } elseif (in_array($jk, ['p', 'perempuan', 'wanita'])) {
+                  $data['jenis_kelamin'] = 'Perempuan';
+               } else {
+                  return ['status' => 'error', 'message' => 'Jenis kelamin tidak dikenal: ' . $jk];
+               }
 
                if ($this->insert($data)) {
                   return $data;
                }
-               return false;
+               return ['status' => 'error', 'message' => 'Gagal menyimpan data'];
             }
             $i++;
          }
       }
-      return false;
+      return ['status' => 'error', 'message' => 'Data CSV tidak ditemukan'];
    }
 
    public function getSiswa($id)

--- a/app/Views/admin/data/import-guru.php
+++ b/app/Views/admin/data/import-guru.php
@@ -144,7 +144,9 @@
                     if (objSub.result == 1) {
                         $("#csv_uploaded_files").prepend('<li class="list-group-item list-group-item-success">&nbsp;' + objSub.index + '.&nbsp;' + objSub.guru.nuptk + '.&nbsp; - ' + objSub.guru.nama_guru + '</li>');
                     } else {
-                        $("#csv_uploaded_files").prepend('<li class="list-group-item list-group-item-danger">&nbsp;' + objSub.index + '.</li>');
+                        var msg = objSub.message ? objSub.message : '(Gagal)';
+                        var cssClass = objSub.result == 2 ? 'list-group-item-warning' : 'list-group-item-danger';
+                        $("#csv_uploaded_files").prepend('<li class="list-group-item ' + cssClass + '">&nbsp;' + objSub.index + '. ' + msg + '</li>');
                     }
                     if (objSub.index == numberOfItems) {
                         $("#csv_upload_spinner .text-csv-importing").hide();

--- a/app/Views/admin/data/import-siswa.php
+++ b/app/Views/admin/data/import-siswa.php
@@ -178,7 +178,9 @@
                     if (objSub.result == 1) {
                         $("#csv_uploaded_files").prepend('<li class="list-group-item list-group-item-success">&nbsp;' + objSub.index + '.&nbsp;' + objSub.siswa.nis + '.&nbsp; - ' + objSub.siswa.nama_siswa +'</li>');
                     } else {
-                        $("#csv_uploaded_files").prepend('<li class="list-group-item list-group-item-danger">&nbsp;' + objSub.index + '.</li>');
+                        var msg = objSub.message ? objSub.message : '(Gagal)';
+                        var cssClass = objSub.result == 2 ? 'list-group-item-warning' : 'list-group-item-danger';
+                        $("#csv_uploaded_files").prepend('<li class="list-group-item ' + cssClass + '">&nbsp;' + objSub.index + '. ' + msg + '</li>');
                     }
                     if (objSub.index == numberOfItems) {
                         $("#csv_upload_spinner .text-csv-importing").hide();


### PR DESCRIPTION
## Perbaikan

### QR Code Generation (#150, #139)
- **PHP 7.4 compatibility**: Named argument syntax `mkdir(..., recursive: true)` menyebabkan ParseError di PHP 7.4. Diganti dengan positional args `mkdir(..., 0777, true)` (9 lokasi)
- **`boolval()` diganti**: `boolval(env('QR_LOGO'))` tidak kompatibel - diganti `filter_var(..., FILTER_VALIDATE_BOOLEAN)`
- **Null safety**: `$generalSettings` bisa null → tambah null coalescing check
- **Error handling**: `generateQrSiswa()` dan `generateQrGuru()` sekarang pakai try-catch, return JSON false jika gagal
- **Dynamic file extension**: Helper `getFileExtension()` untuk deteksi png/svg, hardcoded `.png` diganti
- **Undefined variable**: `$items[]` tanpa inisialisasi di `printQrSiswaSingle()` dan `printQrGuruSingle()`

### CSV Import Siswa (#192)
- **BOM regex terlalu agresif**: `[\x00-\x1F\x80-\xFF]` menghapus semua byte non-ASCII (termasuk huruf seperti 'é', 'ñ'). Dibatasi hanya strip UTF-8 BOM: `^\xEF\xBB\xBF`
- **NIS kehilangan leading zero**: Cast `(int)` pada NIS membuat '00123' → 123. Dihapus, NIS disimpan sebagai string
- **Validasi field required**: NIS, Nama, Kelas wajib diisi sebelum insert
- **Duplicate NIS check**: Cek apakah NIS sudah terdaftar sebelum insert
- **id_kelas existence check**: Validasi apakah id_kelas ada di tb_kelas
- **`getCSVInputValue()`**: `!empty($array[$key])` menganggap value '0' sebagai empty. Diganti `isset($array[$key]) && $array[$key] !== ''`

### CSV Import Guru (#192)
- **Duplicate NUPTK check**: Cek apakah NUPTK sudah terdaftar sebelum insert (sama seperti NIS pada Siswa)
- **Validasi field required**: NUPTK dan Nama Guru wajib diisi
- **Gender validation**: Jenis kelamin tidak dikenal sekarang gagal import, bukan fallback ke 'Laki-laki'
- **BOM regex fix**: Sama seperti Siswa

Closes #150, #139, #192