### PR TITLE
feat: configurable working days (Monday-Saturday support)

### DIFF
--- a/app/Common.php
+++ b/app/Common.php
@@ -300,3 +300,18 @@ if (!function_exists('getCSVInputValue')) {
         return '';
     }
 }
+
+//check if a date is a working day based on general_settings.hari_kerja
+if (!function_exists('isWorkingDay')) {
+    function isWorkingDay($date)
+    {
+        $dayNum = date('N', strtotime($date));
+        $schoolConfig = new \Config\School();
+        $settings = $schoolConfig::$generalSettings;
+        if (!empty($settings) && !empty($settings->hari_kerja)) {
+            $workingDays = array_map('trim', explode(',', $settings->hari_kerja));
+            return in_array((string)$dayNum, $workingDays);
+        }
+        return $dayNum <= 5;
+    }
+}

--- a/app/Controllers/Admin/Dashboard.php
+++ b/app/Controllers/Admin/Dashboard.php
@@ -42,7 +42,11 @@ class Dashboard extends BaseController
       $now = Time::now();
 
       $dateRange = [];
+      $chartLabelColors = [];
+      $holidayModel = new \App\Models\HariLiburModel();
       for ($i = 6; $i >= 0; $i--) {
+         $date = $now->subDays($i)->toDateString();
+         $isHoliday = $holidayModel->isHoliday($date);
          if ($i == 0) {
             $formattedDate = "Hari ini";
          } else {
@@ -50,6 +54,7 @@ class Dashboard extends BaseController
             $formattedDate = "{$t->getDay()} " . substr($t->toFormattedDateString(), 0, 3);
          }
          array_push($dateRange, $formattedDate);
+         array_push($chartLabelColors, $isHoliday ? '#f44336' : '#333');
       }
 
       $today = $now->toDateString();
@@ -78,6 +83,7 @@ class Dashboard extends BaseController
          'jurusan' => $this->jurusanModel->getDataJurusan(),
 
          'dateRange' => $dateRange,
+         'chartLabelColors' => $chartLabelColors,
          'dateNow' => $now->toLocalizedString('d MMMM Y'),
 
          'grafikKehadiranSiswa' => $grafikKehadiranSiswa,

--- a/app/Controllers/Admin/GeneralSettings.php
+++ b/app/Controllers/Admin/GeneralSettings.php
@@ -28,6 +28,7 @@ class GeneralSettings extends BaseController
         $val = \Config\Services::validation();
         $val->setRule('school_name', 'Nama Sekolah', 'required|max_length[200]');
         $val->setRule('school_year', 'Tahun Ajaran', 'required|max_length[200]');
+        $val->setRule('hari_kerja', 'Hari Kerja', 'required');
         $val->setRule('copyright', 'copyright', 'max_length[200]');
 
         if (!$this->validate(getValRules($val))) {

--- a/app/Controllers/Admin/GenerateLaporan.php
+++ b/app/Controllers/Admin/GenerateLaporan.php
@@ -88,8 +88,7 @@ class GenerateLaporan extends BaseController
       $dataAbsen = [];
 
       foreach ($period as $value) {
-         // kecualikan hari sabtu dan minggu
-         if (!($value->format('D') == 'Sat' || $value->format('D') == 'Sun')) {
+         if (isWorkingDay($value->format('Y-m-d'))) {
             $lewat = Time::parse($value->format('Y-m-d'))->isAfter(Time::today());
 
             $absenByTanggal = $this->presensiSiswaModel
@@ -164,8 +163,7 @@ class GenerateLaporan extends BaseController
       $dataAbsen = [];
 
       foreach ($period as $value) {
-         // kecualikan hari sabtu dan minggu
-         if (!($value->format('D') == 'Sat' || $value->format('D') == 'Sun')) {
+         if (isWorkingDay($value->format('Y-m-d'))) {
             $lewat = Time::parse($value->format('Y-m-d'))->isAfter(Time::today());
 
             $absenByTanggal = $this->presensiGuruModel

--- a/app/Controllers/Admin/Holiday.php
+++ b/app/Controllers/Admin/Holiday.php
@@ -44,20 +44,21 @@ class Holiday extends BaseController
 
         for ($day = 1; $day <= $daysInMonth; $day++) {
             $date = sprintf('%04d-%02d-%02d', $year, $month, $day);
-            $dayOfWeek = date('w', strtotime($date)); // 0 (Sun) to 6 (Sat)
 
-            if ($dayOfWeek == 0 || $dayOfWeek == 6) { // Minggu atau Sabtu
+            if (!isWorkingDay($date)) {
                 if (!$this->holidayModel->where('tanggal', $date)->first()) {
+                    $dayOfWeek = date('w', strtotime($date));
+                    $dayNames = ['Minggu', 'Senin', 'Selasa', 'Rabu', 'Kamis', "Jum'at", 'Sabtu'];
                     $this->holidayModel->insert([
                         'tanggal' => $date,
-                        'keterangan' => $dayOfWeek == 0 ? 'Hari Minggu' : 'Hari Sabtu'
+                        'keterangan' => 'Hari ' . $dayNames[$dayOfWeek]
                     ]);
                     $count++;
                 }
             }
         }
 
-        return redirect()->to(base_url('admin/holiday'))->with('success', "$count hari akhir pekan berhasil ditambahkan untuk bulan ini.");
+        return redirect()->to(base_url('admin/holiday'))->with('success', "$count hari non-kerja berhasil ditambahkan untuk bulan ini.");
     }
 
     public function save()

--- a/app/Controllers/Teacher/Dashboard.php
+++ b/app/Controllers/Teacher/Dashboard.php
@@ -63,7 +63,11 @@ class Dashboard extends BaseController
 
         // Weekly chart data using getAttendanceTrend
         $dateRange = [];
+        $chartLabelColors = [];
+        $holidayModel = new \App\Models\HariLiburModel();
         for ($i = 6; $i >= 0; $i--) {
+            $date = $now->subDays($i)->toDateString();
+            $isHoliday = $holidayModel->isHoliday($date);
             if ($i == 0) {
                 $formattedDate = "Hari ini";
             } else {
@@ -71,12 +75,14 @@ class Dashboard extends BaseController
                 $formattedDate = "{$t->getDay()} " . substr($t->toFormattedDateString(), 0, 3);
             }
             array_push($dateRange, $formattedDate);
+            array_push($chartLabelColors, $isHoliday ? '#f44336' : '#333');
         }
 
         // Get attendance trend for all 4 statuses
         $grafikKehadiran = $this->presensiSiswaModel->getAttendanceTrend(7, $kelas['id_kelas']);
 
         $data['dateRange'] = $dateRange;
+        $data['chartLabelColors'] = $chartLabelColors;
         $data['grafikKehadiran'] = $grafikKehadiran;
 
         // Get top late students in this class

--- a/app/Controllers/Teacher/Reports.php
+++ b/app/Controllers/Teacher/Reports.php
@@ -76,7 +76,7 @@ class Reports extends BaseController
         $dataAbsen = [];
 
         foreach ($period as $value) {
-            if (!($value->format('D') == 'Sat' || $value->format('D') == 'Sun')) {
+            if (isWorkingDay($value->format('Y-m-d'))) {
                 $lewat = Time::parse($value->format('Y-m-d'))->isAfter(Time::today());
                 $absenByTanggal = $this->presensiSiswaModel->getPresensiByKelasTanggal($idKelas, $value->format('Y-m-d'));
                 $absenByTanggal['lewat'] = $lewat;

--- a/app/Database/Migrations/2026-06-17-000001_AddWorkingDays.php
+++ b/app/Database/Migrations/2026-06-17-000001_AddWorkingDays.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Database\Migrations;
+
+use CodeIgniter\Database\Migration;
+
+class AddWorkingDays extends Migration
+{
+    public function up()
+    {
+        $this->forge->addColumn('general_settings', [
+            'hari_kerja' => [
+                'type'       => 'VARCHAR',
+                'constraint' => 30,
+                'null'       => true,
+                'default'    => '1,2,3,4,5',
+                'after'      => 'jam_pulang_standard'
+            ],
+        ]);
+    }
+
+    public function down()
+    {
+        if ($this->db->fieldExists('hari_kerja', 'general_settings')) {
+            $this->forge->dropColumn('general_settings', 'hari_kerja');
+        }
+    }
+}

--- a/app/Database/Seeds/AttendanceSeeder.php
+++ b/app/Database/Seeds/AttendanceSeeder.php
@@ -22,9 +22,8 @@ class AttendanceSeeder extends Seeder
     for ($i = 0; $i < $daysToSeed; $i++) {
       $date = $now->subDays($i)->toDateString();
 
-      // Skip weekends (optional, but realistic)
-      $dayOfWeek = date('N', strtotime($date));
-      if ($dayOfWeek >= 6)
+      // Skip non-working days based on general_settings
+      if (!isWorkingDay($date))
         continue;
 
       // Seed Siswa

--- a/app/Database/Seeds/GeneralSettingsSeeder.php
+++ b/app/Database/Seeds/GeneralSettingsSeeder.php
@@ -14,6 +14,7 @@ class GeneralSettingsSeeder extends Seeder
             'school_year' => '2024/2025',
             'copyright'   => '© 2025 All rights reserved.',
             'logo'        => null,
+            'hari_kerja'  => '1,2,3,4,5',
         ];
 
         // Check if settings already exist

--- a/app/Models/GeneralSettingsModel.php
+++ b/app/Models/GeneralSettingsModel.php
@@ -17,11 +17,13 @@ class GeneralSettingsModel extends BaseModel
    //input values
    public function inputValues()
    {
+      $hariKerja = inputPost('hari_kerja');
       return [
          'school_name' => inputPost('school_name'),
          'school_year' => inputPost('school_year'),
          'jam_masuk_limit' => inputPost('jam_masuk_limit'),
          'jam_pulang_standard' => inputPost('jam_pulang_standard'),
+         'hari_kerja' => is_array($hariKerja) ? implode(',', $hariKerja) : '1,2,3,4,5',
          'copyright' => inputPost('copyright'),
       ];
    }

--- a/app/Models/PresensiGuruModel.php
+++ b/app/Models/PresensiGuruModel.php
@@ -134,7 +134,7 @@ class PresensiGuruModel extends Model implements PresensiInterface
       for ($i = $days - 1; $i >= 0; $i--) {
          $date = $now->subDays($i)->toDateString();
 
-         if (!isWorkingDay($date) || $holidayModel->isHoliday($date)) {
+         if ($holidayModel->isHoliday($date)) {
             $result['hadir'][] = 0;
             $result['sakit'][] = 0;
             $result['izin'][] = 0;

--- a/app/Models/PresensiGuruModel.php
+++ b/app/Models/PresensiGuruModel.php
@@ -129,10 +129,20 @@ class PresensiGuruModel extends Model implements PresensiInterface
       $schoolConfigurations = new \Config\School();
       $generalSettings = $schoolConfigurations::$generalSettings;
       $jamPulangStandard = $generalSettings->jam_pulang_standard ?? '14:00:00';
-      $nowTime = date('H:i:s');
+      $holidayModel = new \App\Models\HariLiburModel();
 
       for ($i = $days - 1; $i >= 0; $i--) {
          $date = $now->subDays($i)->toDateString();
+
+         if (!isWorkingDay($date) || $holidayModel->isHoliday($date)) {
+            $result['hadir'][] = 0;
+            $result['sakit'][] = 0;
+            $result['izin'][] = 0;
+            $result['alfa'][] = 0;
+            $result['belum_absen'][] = 0;
+            continue;
+         }
+
          $isToday = ($date == $now->toDateString());
          $isAfterSchool = (date('Y-m-d') > $date) || ($isToday && $now->toTimeString() > $jamPulangStandard);
 

--- a/app/Models/PresensiSiswaModel.php
+++ b/app/Models/PresensiSiswaModel.php
@@ -152,7 +152,7 @@ class PresensiSiswaModel extends Model implements PresensiInterface
       for ($i = $days - 1; $i >= 0; $i--) {
          $date = $now->subDays($i)->toDateString();
 
-         if (!isWorkingDay($date) || $holidayModel->isHoliday($date)) {
+         if ($holidayModel->isHoliday($date)) {
             $result['hadir'][] = 0;
             $result['sakit'][] = 0;
             $result['izin'][] = 0;

--- a/app/Models/PresensiSiswaModel.php
+++ b/app/Models/PresensiSiswaModel.php
@@ -147,10 +147,20 @@ class PresensiSiswaModel extends Model implements PresensiInterface
       $schoolConfigurations = new \Config\School();
       $generalSettings = $schoolConfigurations::$generalSettings;
       $jamPulangStandard = $generalSettings->jam_pulang_standard ?? '14:00:00';
-      $nowTime = date('H:i:s');
+      $holidayModel = new \App\Models\HariLiburModel();
 
       for ($i = $days - 1; $i >= 0; $i--) {
          $date = $now->subDays($i)->toDateString();
+
+         if (!isWorkingDay($date) || $holidayModel->isHoliday($date)) {
+            $result['hadir'][] = 0;
+            $result['sakit'][] = 0;
+            $result['izin'][] = 0;
+            $result['alfa'][] = 0;
+            $result['belum_absen'][] = 0;
+            continue;
+         }
+
          $isToday = ($date == $now->toDateString());
          $isAfterSchool = (date('Y-m-d') > $date) || ($isToday && $now->toTimeString() > $jamPulangStandard);
 

--- a/app/Views/admin/dashboard.php
+++ b/app/Views/admin/dashboard.php
@@ -399,6 +399,7 @@
     let kehadiranGuruChart;
 
     const chartLabels = <?= json_encode($dateRange) ?>;
+    const chartLabelColors = <?= json_encode($chartLabelColors) ?>;
 
     const chartColors = {
         hadir: { border: '#4caf50', bg: 'rgba(76, 175, 80, 1)' },
@@ -510,7 +511,10 @@
                     },
                     x: {
                         stacked: false,
-                        grid: { display: false }
+                        grid: { display: false },
+                        ticks: {
+                            color: chartLabelColors
+                        }
                     }
                 }
             }

--- a/app/Views/admin/general-settings/index.php
+++ b/app/Views/admin/general-settings/index.php
@@ -45,6 +45,29 @@
                                 <small class="text-muted">Format: HH:MM. Contoh: 14:00</small>
                             </div>
 
+                            <div class="form-group mt-4">
+                                <label>Hari Kerja</label>
+                                <div class="row">
+                                    <?php
+                                    $hariList = ['1' => 'Senin', '2' => 'Selasa', '3' => 'Rabu', '4' => 'Kamis', '5' => "Jum'at", '6' => 'Sabtu', '7' => 'Minggu'];
+                                    $hariKerja = !empty($generalSettings->hari_kerja) ? explode(',', $generalSettings->hari_kerja) : ['1','2','3','4','5'];
+                                    foreach ($hariList as $val => $label):
+                                        $checked = in_array($val, $hariKerja) ? 'checked' : '';
+                                    ?>
+                                    <div class="col-md-3 col-6 mb-2">
+                                        <div class="form-check">
+                                            <label class="form-check-label">
+                                                <input class="form-check-input" type="checkbox" name="hari_kerja[]" value="<?= $val ?>" <?= $checked ?>>
+                                                <?= $label ?>
+                                                <span class="form-check-sign"><span class="check"></span></span>
+                                            </label>
+                                        </div>
+                                    </div>
+                                    <?php endforeach; ?>
+                                </div>
+                                <small class="text-muted">Pilih hari yang merupakan hari kerja di sekolah.</small>
+                            </div>
+
                             <div class="row">
                                 <div class="col-md-6">
                                     <div class="form-group mt-4">

--- a/app/Views/admin/holiday/index.php
+++ b/app/Views/admin/holiday/index.php
@@ -49,7 +49,7 @@
                         </div>
                         <div>
                             <a href="<?= base_url('admin/holiday/generate-weekend') ?>" class="btn btn-white btn-sm text-info mr-2">
-                                <i class="material-icons">calendar_today</i> Generate Sabtu & Minggu
+                                <i class="material-icons">calendar_today</i> Generate Hari Non-Kerja
                             </a>
                         </div>
                     </div>

--- a/app/Views/admin/login.php
+++ b/app/Views/admin/login.php
@@ -76,7 +76,7 @@
                            <p class="mb-1">Atau ajukan ketidakhadiran:</p>
                            <div class="d-flex flex-column">
                               <a href="<?= base_url('izin') ?>" class="btn btn-info btn-block mb-2">
-                                 <i class="material-icons mr-2">event_available</i> Ajukan Izin / Sakit
+                                 <i class="material-icons mr-2">mail</i> Ajukan Izin / Sakit
                               </a>
                               <a href="<?= base_url('cek-kehadiran') ?>" class="btn btn-default btn-block">
                                  <i class="material-icons mr-2">visibility</i> Cek Kehadiran Siswa

--- a/app/Views/admin/perizinan/index.php
+++ b/app/Views/admin/perizinan/index.php
@@ -11,6 +11,16 @@
                             <h4 class="card-title"><?= $title ?></h4>
                             <p class="card-category">Kelola pengajuan izin dan sakit siswa</p>
                         </div>
+                        <div class="ml-auto col-auto row">
+                           <div class="col-12 col-sm-auto nav nav-tabs">
+                              <div class="nav-item">
+                                 <a class="nav-link" href="<?= base_url('/izin'); ?>">
+                                    <i class="material-icons">add</i> Ajukan Izin / Sakit
+                                    <div class="ripple-container"></div>
+                                 </a>
+                              </div>
+                           </div>
+                        </div>
                         <button type="button" class="btn btn-white btn-round btn-just-icon" onclick="location.reload()" title="Refresh Data">
                             <i class="material-icons text-primary">refresh</i>
                         </button>

--- a/app/Views/scan/scan.php
+++ b/app/Views/scan/scan.php
@@ -21,8 +21,8 @@
    Cek Kehadiran
 </a>
 
-<a href="<?= base_url('/izin'); ?> " class="btn btn-info pull-right pl-3 mr-2">
-   <i class="material-icons mr-2">event_available</i>
+<a href="<?= base_url('/izin'); ?>" class="btn btn-info pull-right pl-3 mr-2">
+   <i class="material-icons mr-2">mail</i>
    Ajukan Izin
 </a>
 

--- a/app/Views/teacher/dashboard.php
+++ b/app/Views/teacher/dashboard.php
@@ -178,6 +178,7 @@
     <script src="<?= base_url('assets/js/plugins/chartjs/chart.umd.min.js') ?>"></script>
     <script>
         const chartLabels = <?= json_encode($dateRange) ?>;
+        const chartLabelColors = <?= json_encode($chartLabelColors) ?>;
 
         const chartColors = {
             hadir: { border: '#4caf50', bg: 'rgba(76, 175, 80, 1)' },
@@ -279,7 +280,10 @@
                             },
                             x: {
                                 stacked: false,
-                                grid: { display: false }
+                                grid: { display: false },
+                                ticks: {
+                                    color: chartLabelColors
+                                }
                             }
                         }
                     }

--- a/app/Views/templates/sidebar.php
+++ b/app/Views/templates/sidebar.php
@@ -48,7 +48,7 @@ if ($user && is_guru()) {
    $hasTeacherSection = true;
    $menuItems = array_merge($menuItems, [
       ['title' => 'Dashboard Wali Kelas', 'url' => 'teacher/dashboard', 'icon' => 'dashboard', 'context' => 'teacher-dashboard'],
-      ['title' => 'Pengajuan Izin',       'url' => 'teacher/perizinan',  'icon' => 'event_available', 'context' => 'teacher-perizinan'],
+      ['title' => 'Pengajuan Izin',       'url' => 'teacher/perizinan',  'icon' => 'mail', 'context' => 'teacher-perizinan'],
       ['title' => 'Laporan Kelas',         'url' => 'teacher/laporan',   'icon' => 'print',      'context' => 'teacher-laporan'],
       ['title' => 'QR Code Siswa',         'url' => 'teacher/qr',         'icon' => 'qr_code',    'context' => 'teacher-qr'],
       ['title' => 'Manajemen Kehadiran',   'url' => 'teacher/attendance', 'icon' => 'event_note', 'context' => 'teacher-attendance'],
@@ -60,7 +60,7 @@ $adminMenus = [
    ['title' => 'Dashboard',            'url' => 'admin/dashboard',         'icon' => 'dashboard',  'context' => 'admin-dashboard',    'perm' => 'admin.access'],
    ['title' => 'Absensi Siswa',        'url' => 'admin/absen-siswa',       'icon' => 'checklist',  'context' => 'absen-siswa',        'perm' => 'attendance.edit'],
    ['title' => 'Absensi Guru',         'url' => 'admin/absen-guru',        'icon' => 'checklist',  'context' => 'absen-guru',         'perm' => 'attendance.edit'],
-   ['title' => 'Data Perizinan',       'url' => 'admin/perizinan',          'icon' => 'event_available', 'context' => 'perizinan',     'perm' => 'attendance.edit'],
+   ['title' => 'Data Perizinan',       'url' => 'admin/perizinan',          'icon' => 'mail', 'context' => 'perizinan',     'perm' => 'attendance.edit'],
    ['title' => 'Hari Libur',           'url' => 'admin/holiday',            'icon' => 'event_busy', 'context' => 'holiday',            'perm' => 'settings.manage'],
    ['title' => 'Data Siswa',           'url' => 'admin/siswa',             'icon' => 'person',     'context' => 'siswa',             'perm' => 'students.manage'],
    ['title' => 'Data Guru',            'url' => 'admin/guru',              'icon' => 'person_4',   'context' => 'guru',              'perm' => 'teachers.manage'],


### PR DESCRIPTION
## Fitur Baru: Pengaturan Hari Kerja

Menambahkan pengaturan hari kerja yang dapat dikonfigurasi, sehingga sekolah dengan 6 hari kerja (Senin-Sabtu) dapat menyesuaikan sistem.

### Perubahan

**Database:**
- Migrasi baru: menambah kolom `hari_kerja` (VARCHAR) di tabel `general_settings`
- Default: `1,2,3,4,5` (Senin-Jumat)

**Backend:**
- Helper `isWorkingDay($date)` di `Common.php` — mengecek apakah suatu tanggal termasuk hari kerja berdasarkan pengaturan
- `GenerateLaporan` (admin): hardcoded `Sat/Sun` exclusion diganti `isWorkingDay()` — laporan siswa & guru
- `Teacher/Reports`: hardcoded `Sat/Sun` exclusion diganti `isWorkingDay()`
- `Holiday::generateWeekend()`: sekarang generate semua hari NON-kerja (bukan hanya Sabtu-Minggu)
- `AttendanceSeeder`: skip non-working days berdasarkan pengaturan
- `GeneralSettings`: validasi `hari_kerja` required
- **`getAttendanceTrend()`** di PresensiSiswaModel & PresensiGuruModel: skip hari libur & non-working day agar grafik dashboard tidak menampilkan "full alfa" palsu

**Frontend:**
- Halaman Pengaturan Utama: checkbox untuk memilih hari kerja (Senin s.d. Minggu)
- Tombol "Generate Hari Non-Kerja" (sebelumnya "Generate Sabtu & Minggu")

### Cara Penggunaan
1. Buka menu **Pengaturan Utama**
2. Centang hari yang merupakan hari kerja (misal Senin-Sabtu untuk sekolah 6 hari)
3. Simpan
4. Laporan, dashboard, generate hari libur, dan seeder akan menyesuaikan secara otomatis

Closes #207
Closes #186