### PR TITLE
fix: skip new students (zero attendance) dari alert alfa 3 hari

### DIFF
--- a/app/Models/PresensiSiswaModel.php
+++ b/app/Models/PresensiSiswaModel.php
@@ -252,6 +252,12 @@ class PresensiSiswaModel extends Model implements PresensiInterface
       $flaggedStudents = [];
 
       foreach ($students as $student) {
+         // Skip siswa baru yang belum pernah absen sama sekali (misal via import CSV)
+         $totalPresensi = $this->where('id_siswa', $student['id_siswa'])->countAllResults();
+         if ($totalPresensi === 0) {
+            continue;
+         }
+
          $absentCount = 0;
          foreach ($dateStrings as $date) {
             $presensi = $this->where([


### PR DESCRIPTION
## Bug

`getConsecutiveAbsences(3)` memflag siswa baru (import CSV) sebagai "alfa 3 hari berturut-turut" karena mereka belum punya record presensi sama sekali.

```php
// Sebelum: semua siswa dicek, termasuk yang 0 record presensi
foreach ( as ) {
    $absentCount = 0;
    foreach ($dateStrings as $date) {
        $presensi = $this->where([...])->whereIn('id_kehadiran', ['1', '2', '3'])->first();
        if (!$presensi) $absentCount++; // selalu true untuk siswa baru
    }
    if ($absentCount >= 3) $flaggedStudents[] = $student; // false positive
}
```

## Fix

Skip siswa dengan total presensi = 0 (belum pernah absen sama sekali).

```php
$totalPresensi = $this->where('id_siswa', $student['id_siswa'])->countAllResults();
if ($totalPresensi === 0) {
    continue;
}
```

Siswa lama yang benar-benar bolos tetap terdeteksi karena sudah punya record presensi sebelumnya.