### PR TITLE
fix: tambah is_superadmin() guard di endpoint petugas

### DIFF
--- a/app/Controllers/Admin/DataPetugas.php
+++ b/app/Controllers/Admin/DataPetugas.php
@@ -131,6 +131,10 @@ class DataPetugas extends BaseController
 
    public function formEditPetugas($id)
    {
+      if (!is_superadmin()) {
+         return redirect()->to('admin');
+      }
+
       $petugas = $this->petugasModel->getPetugasById($id);
 
       if (empty($petugas)) {
@@ -150,6 +154,10 @@ class DataPetugas extends BaseController
 
    public function updatePetugas()
    {
+      if (!is_superadmin()) {
+         return redirect()->to('admin');
+      }
+
       $idPetugas = $this->request->getVar('id');
 
       $petugasLama = $this->petugasModel->getPetugasById($idPetugas);
@@ -210,6 +218,10 @@ class DataPetugas extends BaseController
 
    public function delete($id)
    {
+      if (!is_superadmin()) {
+         return redirect()->to('admin');
+      }
+
       $result = $this->petugasModel->delete($id);
 
       if ($result) {


### PR DESCRIPTION
## Bug

Tiga endpoint `DataPetugas` tidak memiliki pengecekan `is_superadmin()`:

| Method | Sebelum | Sesudah |
|---|---|---|
| `formEditPetugas()` | ❌ Bisa diakses semua user login | ✅ Hanya SuperAdmin |
| `updatePetugas()` | ❌ StafPetugas bisa ubah role ke superadmin | ✅ Hanya SuperAdmin |
| `delete()` | ❌ StafPetugas bisa hapus petugas lain | ✅ Hanya SuperAdmin |

Kolom `is_superadmin` sudah tidak ada di DB (migrasi ke Shield groups sudah jalan). Kerentanan murni di authorization guard endpoint.

## Fix

Tambah `if (!is_superadmin()) return redirect()->to('admin');` di 3 method tersebut.