### PR TITLE
fix: move inline JS to scripts sections, fix sidebar ctx, fix dead DOMContentLoaded

### DIFF
--- a/app/Controllers/Teacher/Perizinan.php
+++ b/app/Controllers/Teacher/Perizinan.php
@@ -33,7 +33,7 @@ class Perizinan extends BaseController
             return view('teacher/perizinan/index', [
                 'title' => 'Data Perizinan Siswa',
                 'perizinan' => [],
-                'ctx' => 'perizinan',
+                'ctx' => 'teacher-perizinan',
                 'no_class' => true
             ]);
         }
@@ -51,7 +51,7 @@ class Perizinan extends BaseController
         $data = [
             'title' => 'Data Perizinan Siswa',
             'perizinan' => $perizinan,
-            'ctx' => 'perizinan'
+            'ctx' => 'teacher-perizinan'
         ];
         return view('teacher/perizinan/index', $data);
     }

--- a/app/Views/admin/data/data-siswa.php
+++ b/app/Views/admin/data/data-siswa.php
@@ -124,11 +124,8 @@
          });
       }
 
-      document.addEventListener('DOMContentLoaded', function () {
-         $("#checkAll").click(function (e) {
-            console.log(e);
-            $('input:checkbox').not(this).prop('checked', this.checked);
-         });
+      $(document).on('click', '#checkAll', function () {
+         $('input:checkbox').not(this).prop('checked', this.checked);
       });
    </script>
    <?= $this->endSection() ?>

--- a/app/Views/admin/holiday/index.php
+++ b/app/Views/admin/holiday/index.php
@@ -88,6 +88,7 @@
                             <div class="table-responsive">
                                 <table id="tableHoliday" class="table table-hover">
                                     <thead class="text-info">
+                                      <tr>
                                         <th width="40">
                                             <div class="form-check">
                                                 <label class="form-check-label">
@@ -100,6 +101,7 @@
                                         <th>Tanggal</th>
                                         <th>Keterangan</th>
                                         <th>Aksi</th>
+                                      </tr>
                                     </thead>
                                     <tbody>
                                         <?php if (empty($holidays)): ?>
@@ -137,46 +139,38 @@
         </div>
     </div>
 </div>
+<?= $this->endSection() ?>
 
+<?= $this->section('scripts') ?>
 <script>
+    function toggleBulkButton() {
+        const checkedCount = $('.holiday-checkbox:checked').length;
+        const btn = $('#btnBulkDelete');
+        btn.prop('disabled', checkedCount === 0);
+        if (checkedCount > 0) {
+            btn.html(`<i class="material-icons">delete_sweep</i> Hapus Terpilih (${checkedCount})`);
+        } else {
+            btn.html(`<i class="material-icons">delete_sweep</i> Hapus Terpilih`);
+        }
+    }
+
     $(document).ready(function() {
         $('#tableHoliday').DataTable({
             columnDefs: [{ orderable: false, targets: [0, -1] }],
             order: [[2, 'desc']]
         });
-    });
 
-    document.addEventListener('DOMContentLoaded', function() {
-        const checkAll = document.getElementById('checkAll');
-        const checkboxes = document.querySelectorAll('.holiday-checkbox');
-        const btnBulkDelete = document.getElementById('btnBulkDelete');
-        const formBulkDelete = document.getElementById('formBulkDelete');
-
-        // Check All functionality
-        checkAll.addEventListener('change', function() {
-            checkboxes.forEach(cb => {
-                cb.checked = this.checked;
-            });
+        // Check All
+        $('#checkAll').on('change', function() {
+            $('.holiday-checkbox').prop('checked', this.checked);
             toggleBulkButton();
         });
 
-        // Individual checkbox functionality
-        checkboxes.forEach(cb => {
-            cb.addEventListener('change', toggleBulkButton);
-        });
+        // Individual checkbox (delegated karena DataTable)
+        $(document).on('change', '.holiday-checkbox', toggleBulkButton);
 
-        function toggleBulkButton() {
-            const checkedCount = document.querySelectorAll('.holiday-checkbox:checked').length;
-            btnBulkDelete.disabled = checkedCount === 0;
-            if (checkedCount > 0) {
-                btnBulkDelete.innerHTML = `<i class="material-icons">delete_sweep</i> Hapus Terpilih (${checkedCount})`;
-            } else {
-                btnBulkDelete.innerHTML = `<i class="material-icons">delete_sweep</i> Hapus Terpilih`;
-            }
-        }
-
-        // Bulk Delete Action
-        btnBulkDelete.addEventListener('click', function() {
+        // Bulk Delete
+        $('#btnBulkDelete').on('click', function() {
             swal({
                 title: "Hapus Masal?",
                 text: "Hari libur yang dipilih akan dihapus dan presensi akan kembali aktif pada tanggal tersebut.",
@@ -185,32 +179,29 @@
                 dangerMode: true,
             }).then((willDelete) => {
                 if (willDelete) {
-                    formBulkDelete.submit();
+                    $('#formBulkDelete').submit();
                 }
             });
         });
 
-        // Single Delete Action
-        const deleteSingleBtns = document.querySelectorAll('.btn-delete-single');
-        deleteSingleBtns.forEach(btn => {
-            btn.addEventListener('click', function() {
-                const id = this.getAttribute('data-id');
-                swal({
-                    title: "Hapus Hari Libur?",
-                    text: "Sistem akan kembali mengaktifkan presensi di tanggal ini.",
-                    icon: "warning",
-                    buttons: ["Batal", "Hapus"],
-                    dangerMode: true,
-                }).then((willDelete) => {
-                    if (willDelete) {
-                        const form = document.createElement('form');
-                        form.action = `<?= base_url('admin/holiday/delete') ?>/${id}`;
-                        form.method = 'POST';
-                        form.innerHTML = `<?= csrf_field() ?><input type="hidden" name="_method" value="DELETE">`;
-                        document.body.appendChild(form);
-                        form.submit();
-                    }
-                });
+        // Single Delete (delegated karena DataTable)
+        $(document).on('click', '.btn-delete-single', function() {
+            const id = $(this).data('id');
+            swal({
+                title: "Hapus Hari Libur?",
+                text: "Sistem akan kembali mengaktifkan presensi di tanggal ini.",
+                icon: "warning",
+                buttons: ["Batal", "Hapus"],
+                dangerMode: true,
+            }).then((willDelete) => {
+                if (willDelete) {
+                    const form = document.createElement('form');
+                    form.action = '<?= base_url('admin/holiday/delete') ?>' + '/' + id;
+                    form.method = 'POST';
+                    form.innerHTML = '<?= csrf_field() ?><input type="hidden" name="_method" value="DELETE">';
+                    document.body.appendChild(form);
+                    form.submit();
+                }
             });
         });
     });

--- a/app/Views/admin/kelas/index.php
+++ b/app/Views/admin/kelas/index.php
@@ -87,11 +87,7 @@
 
 <?= $this->section('scripts') ?>
 <script>
-  document.addEventListener('DOMContentLoaded', function () {
-    fetchKelasJurusanData('kelas', '#dataKelas');
-    fetchKelasJurusanData('jurusan', '#dataJurusan');
-  });
-
-
+  fetchKelasJurusanData('kelas', '#dataKelas');
+  fetchKelasJurusanData('jurusan', '#dataJurusan');
 </script>
 <?= $this->endSection() ?>

--- a/app/Views/admin/perizinan/index.php
+++ b/app/Views/admin/perizinan/index.php
@@ -110,74 +110,68 @@
         </div>
     </div>
 </div>
+<?= $this->endSection() ?>
 
+<?= $this->section('scripts') ?>
 <script>
     $(document).ready(function() {
         $('#tablePerizinan').DataTable({
             columnDefs: [{ orderable: false, targets: [-1] }],
             order: [[2, 'desc']]
         });
-    });
 
-    document.addEventListener('DOMContentLoaded', function() {
-        // Konfirmasi Status (Setujui/Tolak)
-        const btns = document.querySelectorAll('.btn-konfirmasi');
-        btns.forEach(btn => {
-            btn.addEventListener('click', function() {
-                const id = this.getAttribute('data-id');
-                const status = this.getAttribute('data-status');
+        // Konfirmasi Status (Setujui/Tolak) - delegated karena DataTable
+        $(document).on('click', '.btn-konfirmasi', function() {
+            const id = $(this).data('id');
+            const status = $(this).data('status');
 
-                swal({
-                    title: "Konfirmasi",
-                    text: `Apakah Anda yakin ingin mengubah status menjadi ${status}?`,
-                    icon: "warning",
-                    buttons: ["Batal", "Ya, Lanjutkan"],
-                    dangerMode: status === 'Ditolak',
-                }).then((willProcess) => {
-                    if (willProcess) {
-                        fetch('<?= base_url('admin/perizinan/konfirmasi') ?>', {
-                                method: 'POST',
-                                headers: {
-                                    'Content-Type': 'application/x-www-form-urlencoded',
-                                    'X-Requested-With': 'XMLHttpRequest'
-                                },
-                                body: `id_perizinan=${id}&status=${status}&<?= csrf_token() ?>=<?= csrf_hash() ?>`
-                            })
-                            .then(response => response.json())
-                            .then(result => {
-                                if (result.status === 'success') {
-                                    swal("Berhasil", result.message, "success").then(() => {
-                                        location.reload();
-                                    });
-                                } else {
-                                    swal("Gagal", result.message, "error");
-                                }
-                            })
-                            .catch(err => {
-                                console.error(err);
-                                swal("Error", "Terjadi kesalahan saat memproses data.", "error");
-                            });
-                    }
-                });
+            swal({
+                title: "Konfirmasi",
+                text: `Apakah Anda yakin ingin mengubah status menjadi ${status}?`,
+                icon: "warning",
+                buttons: ["Batal", "Ya, Lanjutkan"],
+                dangerMode: status === 'Ditolak',
+            }).then((willProcess) => {
+                if (willProcess) {
+                    fetch('<?= base_url('admin/perizinan/konfirmasi') ?>', {
+                            method: 'POST',
+                            headers: {
+                                'Content-Type': 'application/x-www-form-urlencoded',
+                                'X-Requested-With': 'XMLHttpRequest'
+                            },
+                            body: `id_perizinan=${id}&status=${status}&<?= csrf_token() ?>=<?= csrf_hash() ?>`
+                        })
+                        .then(response => response.json())
+                        .then(result => {
+                            if (result.status === 'success') {
+                                swal("Berhasil", result.message, "success").then(() => {
+                                    location.reload();
+                                });
+                            } else {
+                                swal("Gagal", result.message, "error");
+                            }
+                        })
+                        .catch(err => {
+                            console.error(err);
+                            swal("Error", "Terjadi kesalahan saat memproses data.", "error");
+                        });
+                }
             });
         });
 
-        // Konfirmasi Hapus
-        const deleteBtns = document.querySelectorAll('.btn-delete');
-        deleteBtns.forEach(btn => {
-            btn.addEventListener('click', function() {
-                const form = this.closest('.form-delete');
-                swal({
-                    title: "Hapus Data?",
-                    text: "Data yang dihapus tidak dapat dikembalikan!",
-                    icon: "warning",
-                    buttons: ["Batal", "Hapus"],
-                    dangerMode: true,
-                }).then((willDelete) => {
-                    if (willDelete) {
-                        form.submit();
-                    }
-                });
+        // Konfirmasi Hapus - delegated karena DataTable
+        $(document).on('click', '.btn-delete', function() {
+            const form = $(this).closest('.form-delete');
+            swal({
+                title: "Hapus Data?",
+                text: "Data yang dihapus tidak dapat dikembalikan!",
+                icon: "warning",
+                buttons: ["Batal", "Hapus"],
+                dangerMode: true,
+            }).then((willDelete) => {
+                if (willDelete) {
+                    form.submit();
+                }
             });
         });
     });

--- a/app/Views/scan/scan.php
+++ b/app/Views/scan/scan.php
@@ -146,9 +146,10 @@ $waktu == 'Masuk' ? $oppBtn = 'pulang' : $oppBtn = 'masuk';
    </div>
 </div>
 </div>
+<?= $this->endSection() ?>
 
+<?= $this->section('scripts') ?>
 <script type="text/javascript" src="<?= base_url('assets/js/plugins/zxing/zxing.min.js') ?>"></script>
-<script src="<?= base_url('assets/js/core/jquery-3.5.1.min.js') ?>"></script>
 <script type="text/javascript">
    let selectedDeviceId = null;
    let audio = new Audio("<?= base_url('assets/audio/beep.mp3'); ?>");

--- a/app/Views/teacher/perizinan/index.php
+++ b/app/Views/teacher/perizinan/index.php
@@ -95,54 +95,52 @@
         <?php endif; ?>
     </div>
 </div>
+<?= $this->endSection() ?>
 
+<?= $this->section('scripts') ?>
 <script>
     $(document).ready(function() {
         $('#tablePerizinan').DataTable({
             columnDefs: [{ orderable: false, targets: [-1] }],
             order: [[2, 'desc']]
         });
-    });
 
-    document.addEventListener('DOMContentLoaded', function() {
-        const btns = document.querySelectorAll('.btn-konfirmasi');
-        btns.forEach(btn => {
-            btn.addEventListener('click', function() {
-                const id = this.getAttribute('data-id');
-                const status = this.getAttribute('data-status');
+        // Konfirmasi Status - delegated karena DataTable
+        $(document).on('click', '.btn-konfirmasi', function() {
+            const id = $(this).data('id');
+            const status = $(this).data('status');
 
-                swal({
-                    title: "Konfirmasi",
-                    text: `Apakah Anda yakin ingin mengubah status menjadi ${status}?`,
-                    icon: "warning",
-                    buttons: ["Batal", "Ya, Lanjutkan"],
-                    dangerMode: status === 'Ditolak',
-                }).then((willProcess) => {
-                    if (willProcess) {
-                        fetch('<?= base_url('teacher/perizinan/konfirmasi') ?>', {
-                                method: 'POST',
-                                headers: {
-                                    'Content-Type': 'application/x-www-form-urlencoded',
-                                    'X-Requested-With': 'XMLHttpRequest'
-                                },
-                                body: `id_perizinan=${id}&status=${status}&<?= csrf_token() ?>=<?= csrf_hash() ?>`
-                            })
-                            .then(response => response.json())
-                            .then(result => {
-                                if (result.status === 'success') {
-                                    swal("Berhasil", result.message, "success").then(() => {
-                                        location.reload();
-                                    });
-                                } else {
-                                    swal("Gagal", result.message, "error");
-                                }
-                            })
-                            .catch(err => {
-                                console.error(err);
-                                swal("Error", "Terjadi kesalahan saat memproses data.", "error");
-                            });
-                    }
-                });
+            swal({
+                title: "Konfirmasi",
+                text: `Apakah Anda yakin ingin mengubah status menjadi ${status}?`,
+                icon: "warning",
+                buttons: ["Batal", "Ya, Lanjutkan"],
+                dangerMode: status === 'Ditolak',
+            }).then((willProcess) => {
+                if (willProcess) {
+                    fetch('<?= base_url('teacher/perizinan/konfirmasi') ?>', {
+                            method: 'POST',
+                            headers: {
+                                'Content-Type': 'application/x-www-form-urlencoded',
+                                'X-Requested-With': 'XMLHttpRequest'
+                            },
+                            body: `id_perizinan=${id}&status=${status}&<?= csrf_token() ?>=<?= csrf_hash() ?>`
+                        })
+                        .then(response => response.json())
+                        .then(result => {
+                            if (result.status === 'success') {
+                                swal("Berhasil", result.message, "success").then(() => {
+                                    location.reload();
+                                });
+                            } else {
+                                swal("Gagal", result.message, "error");
+                            }
+                        })
+                        .catch(err => {
+                            console.error(err);
+                            swal("Error", "Terjadi kesalahan saat memproses data.", "error");
+                        });
+                }
             });
         });
     });

--- a/app/Views/templates/js.php
+++ b/app/Views/templates/js.php
@@ -1,6 +1,6 @@
 <?php
 // Update this when you make changes to JS files
-$assetVersion = '1.0.0';
+$assetVersion = '1.0.1';
 ?>
 <!--   Core JS Files   -->
 <script src="<?= base_url('assets/js/core/jquery-3.5.1.min.js?v=' . $assetVersion) ?>"></script>

--- a/app/Views/templates/starting_page_layout.php
+++ b/app/Views/templates/starting_page_layout.php
@@ -87,6 +87,8 @@
          textCancel: "Batalkan"
       };
    </script>
+
+    <?= $this->renderSection("scripts") ?>
 </body>
 
 </html>


### PR DESCRIPTION
## Masalah

1. jQuery-dependent `<script>` ditempatkan di dalam `section('content')` yang dieksekusi **sebelum** jQuery diload (karena layout me-render content sebelum `templates/js`).
2. `document.addEventListener('DOMContentLoaded', ...)` di dalam `section('scripts')` tidak pernah jalan — DOM sudah siap saat scripts dirender.
3. Sidebar menu `Pengajuan Izin` untuk wali kelas salah highlight ke `Data Perizinan` karena controller `Teacher/Perizinan` menggunakan `ctx => 'perizinan'` (sama dengan admin), bukan `ctx => 'teacher-perizinan'`.

## Perubahan

### Fix script loading order
- `admin/perizinan/index.php` — script pindah ke `section('scripts')`, event delegation gantikan DOMContentLoaded
- `admin/holiday/index.php` — script pindah ke `section('scripts')`, event delegation gantikan DOMContentLoaded
- `teacher/perizinan/index.php` — sama
- `scan/scan.php` — script pindah ke `section('scripts')`, double load jQuery dihapus
- `templates/starting_page_layout.php` — tambah `renderSection('scripts')`
- `templates/js.php` — bump asset version ke `1.0.1`

### Fix dead DOMContentLoaded
- `admin/kelas/index.php` — `fetchKelasJurusanData` langsung jalan
- `admin/data/data-siswa.php` — checkAll binding ganti ke `.on('click')`

### Fix sidebar context
- `app/Controllers/Teacher/Perizinan.php` — ubah `ctx => 'perizinan'` menjadi `ctx => 'teacher-perizinan'` pada kedua cabang (index with and without class)